### PR TITLE
[Feat] 학생 다중 삭제 API (다중 삭제) 

### DIFF
--- a/src/main/java/classfit/example/classfit/student/controller/StudentControllerImpl.java
+++ b/src/main/java/classfit/example/classfit/student/controller/StudentControllerImpl.java
@@ -45,12 +45,12 @@ public class StudentControllerImpl {
         return ApiResponse.success(studentList, 200, "FIND STUDENTS");
     }
 
-    @DeleteMapping("/{studentId}")
+    @DeleteMapping("/")
     @Operation(summary = "학생 정보 삭제", description = "학생 정보 삭제하는 API 입니다. ")
-    public ApiResponse<Long> deleteStudent(@PathVariable Long studentId) {
+    public ApiResponse<List<Long>> deleteStudent(@RequestParam List<Long> studentIds) {
 
-        studentService.deleteStudent(studentId);
-        return ApiResponse.success(studentId, 200, "DELETED STUDENT");
+        studentService.deleteStudent(studentIds);
+        return ApiResponse.success(studentIds.stream().toList(), 200, "DELETED STUDENT");
     }
 
     @PatchMapping("/{studentId}")

--- a/src/main/java/classfit/example/classfit/student/controller/StudentControllerImpl.java
+++ b/src/main/java/classfit/example/classfit/student/controller/StudentControllerImpl.java
@@ -2,7 +2,7 @@ package classfit.example.classfit.student.controller;
 
 import classfit.example.classfit.common.ApiResponse;
 import classfit.example.classfit.student.dto.request.StudentRequest;
-import classfit.example.classfit.student.dto.request.UpdateStudentRequest;
+import classfit.example.classfit.student.dto.request.StudentUpdateRequest;
 import classfit.example.classfit.student.dto.response.StudentInfoResponse;
 import classfit.example.classfit.student.dto.response.StudentResponse;
 import classfit.example.classfit.student.service.StudentService;
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/student")
 @RequiredArgsConstructor
-@Tag(name = "Student API", description = "학생 관련 API")
+@Tag(name = "학생 API", description = "학생 관련 API")
 public class StudentControllerImpl {
 
     private final StudentService studentService;
@@ -47,19 +47,19 @@ public class StudentControllerImpl {
 
     @DeleteMapping("/{studentId}")
     @Operation(summary = "학생 정보 삭제", description = "학생 정보 삭제하는 API 입니다. ")
-    public ApiResponse<StudentResponse> deleteStudent(@PathVariable Long studentId) {
+    public ApiResponse<Long> deleteStudent(@PathVariable Long studentId) {
 
         studentService.deleteStudent(studentId);
-        return ApiResponse.success(null, 200, "DELETED STUDENT");
+        return ApiResponse.success(studentId, 200, "DELETED STUDENT");
     }
 
     @PatchMapping("/{studentId}")
     @Operation(summary = "학생 정보 수정", description = "학생 정보를 수정하는 API 입니다. ")
-    public ApiResponse<StudentResponse> updateStudent(
-        @PathVariable Long studentId, @RequestBody @Valid UpdateStudentRequest req) {
+    public ApiResponse<Long> updateStudent(
+        @PathVariable Long studentId, @RequestBody @Valid StudentUpdateRequest req) {
 
         studentService.updateStudent(studentId, req);
-        return ApiResponse.success(null, 200, "UPDATED STUDENT");
+        return ApiResponse.success(studentId, 200, "UPDATED STUDENT");
     }
 
     @GetMapping("/{studentId}")

--- a/src/main/java/classfit/example/classfit/student/dto/request/StudentRequest.java
+++ b/src/main/java/classfit/example/classfit/student/dto/request/StudentRequest.java
@@ -2,7 +2,7 @@ package classfit.example.classfit.student.dto.request;
 
 import classfit.example.classfit.common.Gender;
 import classfit.example.classfit.domain.Student;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -11,21 +11,28 @@ import java.util.List;
 
 public record StudentRequest
     (
-        @NotNull @Size(max = 30) String name,
+        @NotBlank(message = "이름은 필수 항목입니다.")
+        @Size(max = 30) String name,
 
-        @NotNull Gender gender,
+        @NotBlank(message = "성별은 필수 항목입니다.") Gender gender,
 
-        @NotNull @Past LocalDate birth,
+        @NotBlank(message = "생년월일은 필수 항목입니다.")
+        @Past LocalDate birth,
 
-        @NotNull @Size(max = 14) @Pattern(regexp = "^[0-9\\-]+$") String studentNumber,
+        @NotBlank(message = "학생 전화번호는 필수 항목입니다.")
+        @Size(max = 14) @Pattern(regexp = "^[0-9\\-]+$") String studentNumber,
 
-        @NotNull @Size(max = 14) @Pattern(regexp = "^[0-9\\-]+$") String parentNumber,
+        @NotBlank(message = "학부모 전화번호는 필수 항목입니다.")
+        @Size(max = 14) @Pattern(regexp = "^[0-9\\-]+$") String parentNumber,
 
-        @NotNull @Size(max = 10) String grade,
+        @NotBlank(message = "학년은 필수 항목입니다.")
+        @Size(max = 10) String grade,
 
-        @NotNull @Size(max = 30) List<Long> subClassList,
+        @NotBlank(message = "클래스는 필수 항목입니다.")
+        @Size(max = 30) List<Long> subClassList,
 
-        @NotNull @Size(max = 30) String address,
+        @NotBlank(message = "주소 등록은 필수 항목입니다.")
+        @Size(max = 30) String address,
 
         String remark,
 

--- a/src/main/java/classfit/example/classfit/student/dto/request/StudentUpdateRequest.java
+++ b/src/main/java/classfit/example/classfit/student/dto/request/StudentUpdateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.util.List;
 
-public record UpdateStudentRequest
+public record StudentUpdateRequest
     (
         @Size(max = 30) String name,
 
@@ -31,5 +31,5 @@ public record UpdateStudentRequest
 
         String counselingLog
     ) {
-    
+
 }

--- a/src/main/java/classfit/example/classfit/student/dto/response/StudentResponse.java
+++ b/src/main/java/classfit/example/classfit/student/dto/response/StudentResponse.java
@@ -1,10 +1,7 @@
 package classfit.example.classfit.student.dto.response;
 
-import classfit.example.classfit.common.Gender;
 import classfit.example.classfit.domain.Student;
-import classfit.example.classfit.domain.SubClass;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import java.util.List;
 import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -13,14 +10,7 @@ public record StudentResponse
     (
         Long studentId,
         String name,
-        Gender gender,
         String studentNumber,
-        String parentNumber,
-        String grade,
-        List<SubClass> subClassList,
-        String address,
-        String remark,
-        String counselingLog,
         boolean isStudent
     ) {
 
@@ -29,7 +19,6 @@ public record StudentResponse
             .studentId(student.getId())
             .name(student.getName())
             .studentNumber(student.getStudentNumber())
-            .grade(student.getGrade())
             .isStudent(student.isStudent())
             .build();
     }

--- a/src/main/java/classfit/example/classfit/student/service/StudentService.java
+++ b/src/main/java/classfit/example/classfit/student/service/StudentService.java
@@ -7,7 +7,7 @@ import classfit.example.classfit.domain.Student;
 import classfit.example.classfit.domain.SubClass;
 import classfit.example.classfit.exception.ClassfitException;
 import classfit.example.classfit.student.dto.request.StudentRequest;
-import classfit.example.classfit.student.dto.request.UpdateStudentRequest;
+import classfit.example.classfit.student.dto.request.StudentUpdateRequest;
 import classfit.example.classfit.student.dto.response.StudentInfoResponse;
 import classfit.example.classfit.student.dto.response.StudentResponse;
 import classfit.example.classfit.student.repository.StudentRepository;
@@ -87,7 +87,7 @@ public class StudentService {
     }
 
     @Transactional
-    public void updateStudent(Long studentId, UpdateStudentRequest req) {
+    public void updateStudent(Long studentId, StudentUpdateRequest req) {
         Student student = studentRepository.findById(studentId).orElseThrow(
             () -> new ClassfitException("해당하는 학생 정보가 존재하지 않습니다.", HttpStatus.NOT_FOUND));
 
@@ -95,9 +95,9 @@ public class StudentService {
         updateStudentSubClasses(student, req.subClassList());
     }
 
-    private void updateStudentFields(Student student, UpdateStudentRequest req) {
+    private void updateStudentFields(Student student, StudentUpdateRequest req) {
         try {
-            Field[] fields = UpdateStudentRequest.class.getDeclaredFields();
+            Field[] fields = StudentUpdateRequest.class.getDeclaredFields();
 
             for (Field field : fields) {
 

--- a/src/main/java/classfit/example/classfit/student/service/StudentService.java
+++ b/src/main/java/classfit/example/classfit/student/service/StudentService.java
@@ -46,13 +46,16 @@ public class StudentService {
     }
 
     @Transactional
-    public void deleteStudent(Long studentId) {
+    public void deleteStudent(List<Long> studentIds) {
 
-        Student student = studentRepository.findById(studentId).orElseThrow(
-            () -> new ClassfitException("해당하는 학생 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
-
-        classStudentRepository.deleteAllByStudentId(studentId);
-        studentRepository.delete(student);
+        studentIds.stream()
+            .map(studentId -> studentRepository.findById(studentId).orElseThrow(
+                () -> new ClassfitException("해당하는 학생 정보를 찾을 수 없습니다: ID = " + studentId,
+                    HttpStatus.NOT_FOUND)))
+            .forEach(student -> {
+                classStudentRepository.deleteAllByStudentId(student.getId());
+                studentRepository.delete(student);
+            });
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
1. 기존 학생 단일 선택에서 다중 선택으로 기능 수정

2. DTO 리네이밍

3. @NotBlank 추가 및 DTO 유효성 검증 메시지 추가 

4. StudentResponse DTO 수정

---

기존 `api/v1/student/{studentId}`에서  `api/v1/student/` 로 URL EndPoint 수정했습니다.

![image](https://github.com/user-attachments/assets/37bdd0de-1523-44fa-a3c1-b0243daed23f)
