### PR TITLE
[Feat] 이메일 전송 및 인증코드 검증 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'        // Mail
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'  // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/classfit/example/classfit/ClassfitApplication.java
+++ b/src/main/java/classfit/example/classfit/ClassfitApplication.java
@@ -11,8 +11,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 public class ClassfitApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ClassfitApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ClassfitApplication.class, args);
+    }
 
 }

--- a/src/main/java/classfit/example/classfit/config/MailConfig.java
+++ b/src/main/java/classfit/example/classfit/config/MailConfig.java
@@ -1,0 +1,55 @@
+package classfit.example.classfit.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class MailConfig {
+
+    private static final String MAIL_SMTP_AUTH = "mail.smtp.auth";
+    private static final String MAIL_SMTP_STARTTLS_ENABLE = "mail.smtp.starttls.enable";
+
+    @Value("${spring.mail.host}")
+    private String host;
+
+    @Value("${spring.mail.username}")
+    private String username;
+
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Value("${spring.mail.password}")
+    private String password;
+
+    @Value("${spring.mail.properties.mail.starttls.enable}")
+    private boolean startTlsEnable;
+
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Bean
+    public JavaMailSender googleMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+
+        Properties properties = javaMailSender.getJavaMailProperties();
+        properties.put(MAIL_SMTP_AUTH, auth);
+        properties.put(MAIL_SMTP_STARTTLS_ENABLE, startTlsEnable);
+
+        javaMailSender.setJavaMailProperties(properties);
+        javaMailSender.setDefaultEncoding("UTF-8");
+
+        return javaMailSender;
+    }
+}

--- a/src/main/java/classfit/example/classfit/config/RedisConfig.java
+++ b/src/main/java/classfit/example/classfit/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package classfit.example.classfit.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
+++ b/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
@@ -5,6 +5,8 @@ import classfit.example.classfit.mail.dto.request.EmailAuthRequest;
 import classfit.example.classfit.mail.dto.request.EmailAuthVerifyRequest;
 import classfit.example.classfit.mail.dto.response.EmailAuthResponse;
 import classfit.example.classfit.mail.service.EmailAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -12,17 +14,20 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/mail")
+@Tag(name = "이메일 API", description = "이메일 관련 API")
 public class EmailAuthController {
 
     private final EmailAuthService emailAuthService;
 
     @GetMapping("/send")
+    @Operation(summary = "이메일 전송", description = "특정 이메일에 인증코드를 전송하는 API 입니다.")
     public ApiResponse<EmailAuthResponse> sendMail(@RequestBody @Valid EmailAuthRequest request) {
         EmailAuthResponse emailAuthResponse = emailAuthService.sendEmail(request);
         return ApiResponse.success(emailAuthResponse, 200, "이메일이 전송되었습니다");
     }
 
     @PostMapping("/verify")
+    @Operation(summary = "이메일 인증코드 검증", description = "인증코드를 검증하는 API 입니다.")
     public ApiResponse<EmailAuthResponse> verifyMail(@RequestBody @Valid EmailAuthVerifyRequest request) {
         EmailAuthResponse emailAuthResponse = emailAuthService.verifyAuthCode(request);
         return ApiResponse.success(emailAuthResponse, 200, "정상적으로 확인되었습니다.");

--- a/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
+++ b/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
@@ -1,0 +1,30 @@
+package classfit.example.classfit.mail.controller;
+
+import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.mail.dto.request.EmailAuthRequest;
+import classfit.example.classfit.mail.dto.request.EmailAuthVerifyRequest;
+import classfit.example.classfit.mail.dto.response.EmailAuthResponse;
+import classfit.example.classfit.mail.service.EmailAuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mail")
+public class EmailAuthController {
+
+    private final EmailAuthService emailAuthService;
+
+    @GetMapping("/send")
+    public ApiResponse<EmailAuthResponse> sendMail(@RequestBody @Valid EmailAuthRequest request) {
+        EmailAuthResponse emailAuthResponse = emailAuthService.sendEmail(request);
+        return ApiResponse.success(emailAuthResponse, 200, "이메일이 전송되었습니다");
+    }
+
+    @PostMapping("/verify")
+    public ApiResponse<EmailAuthResponse> verifyMail(@RequestBody @Valid EmailAuthVerifyRequest request) {
+        EmailAuthResponse emailAuthResponse = emailAuthService.verifyAuthCode(request);
+        return ApiResponse.success(emailAuthResponse, 200, "정상적으로 확인되었습니다.");
+    }
+}

--- a/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthRequest.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthRequest.java
@@ -1,0 +1,12 @@
+package classfit.example.classfit.mail.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailAuthRequest
+    (
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "올바르지 않은 이메일 형식입니다.")
+        String email
+    ) {
+}

--- a/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthVerifyRequest.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthVerifyRequest.java
@@ -1,0 +1,15 @@
+package classfit.example.classfit.mail.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailAuthVerifyRequest
+    (
+        @NotBlank(message = "이메일을 입력해 주세요")
+        @Email(message = "올바르지 않은 이메일 형식입니다.")
+        String email,
+
+        @NotBlank(message = "인증 코드는 필수 입력입니다.")
+        String code
+    ) {
+}

--- a/src/main/java/classfit/example/classfit/mail/dto/response/EmailAuthResponse.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/response/EmailAuthResponse.java
@@ -1,0 +1,16 @@
+package classfit.example.classfit.mail.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record EmailAuthResponse
+    (
+        String email
+    ) {
+
+    public static EmailAuthResponse from(final String email) {
+        return EmailAuthResponse.builder()
+            .email(email)
+            .build();
+    }
+}

--- a/src/main/java/classfit/example/classfit/mail/service/EmailAuthService.java
+++ b/src/main/java/classfit/example/classfit/mail/service/EmailAuthService.java
@@ -1,0 +1,95 @@
+package classfit.example.classfit.mail.service;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.mail.dto.request.EmailAuthRequest;
+import classfit.example.classfit.mail.dto.request.EmailAuthVerifyRequest;
+import classfit.example.classfit.mail.dto.response.EmailAuthResponse;
+import classfit.example.classfit.member.repository.MemberRepository;
+import classfit.example.classfit.util.RedisUtil;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
+    @Transactional
+    public EmailAuthResponse sendEmail(EmailAuthRequest request) {
+
+        boolean existsByEmail = memberRepository.existsByEmail(fromEmail);
+
+        if (existsByEmail) {
+            throw new ClassfitException("이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
+        }
+
+        String email = createEmailForm(request.email());
+        return EmailAuthResponse.from(email);
+    }
+
+    @Transactional
+    public EmailAuthResponse verifyAuthCode(EmailAuthVerifyRequest request) {
+        String authCode = redisUtil.getData(request.email()).toString();
+
+        if (!authCode.equals(request.code())) {
+            throw new ClassfitException("인증 번호가 일치하지 않습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        return EmailAuthResponse.from(request.email());
+    }
+
+    private String createEmailForm(String email) {
+
+        String authCode = createdCode();
+
+        try {
+            MimeMessage message = javaMailSender.createMimeMessage();
+            message.addRecipients(MimeMessage.RecipientType.TO, email);
+            message.setSubject("[ClassFit] 인증코드 확인");
+            message.setText(setContext(authCode), "utf-8", "html");
+
+            javaMailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new ClassfitException("이메일 전송에 실패하였습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        redisUtil.setDataExpire(email, authCode, 60 * 10L);         // 10분동안 유효
+        return email;
+    }
+
+    private String createdCode() {
+        int leftLimit = 48;             // number '0'
+        int rightLimit = 122;           // alphabet 'z'
+        int targetStringLength = 8;
+        Random random = new Random();
+
+        return random.ints(leftLimit, rightLimit + 1)
+            .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))
+            .limit(targetStringLength)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+            .toString();
+    }
+
+    private String setContext(String authCode) {
+        Context context = new Context();
+        context.setVariable("code", authCode);
+        return templateEngine.process("mail", context);     // mail.html
+    }
+}

--- a/src/main/java/classfit/example/classfit/member/repository/MemberRepository.java
+++ b/src/main/java/classfit/example/classfit/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/classfit/example/classfit/util/RedisUtil.java
+++ b/src/main/java/classfit/example/classfit/util/RedisUtil.java
@@ -1,0 +1,35 @@
+package classfit.example.classfit.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public Object getData(String key) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(key);
+    }
+
+    public void setData(String key, Object value) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(key, value);
+    }
+
+    public void setDataExpire(String key, Object value, long duration) {
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        Duration expireDuration = Duration.ofSeconds(duration);
+        valueOperations.set(key, value, expireDuration);
+    }
+
+    public void deleteData(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div style="margin:100px; color: black">
+    <h1 style="color: black"> 안녕하세요.</h1>
+    <h1 style="color: black"> ClassFit 입니다.</h1>
+    <br>
+    <p style="color: black"> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <br>
+
+    <div align="center" style="border:1px solid black; padding:15px; font-family:verdana;">
+        <h3> 회원가입 인증 코드 </h3>
+        <div style="font-size:130%; color:darkred" th:text="${code}"></div>
+    </div>
+    <br/>
+</div>
+</body>
+</html>


### PR DESCRIPTION
# 1. 이메일 전송 API

![image](https://github.com/user-attachments/assets/dc202ef7-729e-420f-8887-1d223e07218b)

---

![image](https://github.com/user-attachments/assets/f318e30e-245c-4e51-a941-84d0721597b8)

---

# 2. 이메일 검증 API

![image](https://github.com/user-attachments/assets/cdfb6fbc-5c6a-47fb-bad2-86bc00012123)

---

* 이메일 형식을 위해 타임리프 라이브러리 의존성 추가해 놨습니다.
* EC2와 ElasticCache(Reids) 연결