### PR TITLE
[feat] 회원가입 기능 구현

### DIFF
--- a/src/main/java/classfit/example/classfit/config/SecurityConfig.java
+++ b/src/main/java/classfit/example/classfit/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package classfit.example.classfit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity security) throws Exception {
+        security
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        security
+            .authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()  // 스웨거 관련 엔드포인트 허용
+                .requestMatchers("/api/v1/login", "/api/v1/sign_in", "/api/v1/reissue", "/api/v1/mail/send", "/api/v1/mail/verify").permitAll()
+                .requestMatchers("/api/v1/**").hasAnyRole("MEMBER", "ADMIN")
+                .requestMatchers("/admin").hasRole("ADMIN")
+                .anyRequest().authenticated());
+
+        return security.build();
+    }
+
+}

--- a/src/main/java/classfit/example/classfit/member/controller/MemberController.java
+++ b/src/main/java/classfit/example/classfit/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package classfit.example.classfit.member.controller;
+
+import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.member.dto.request.MemberRequest;
+import classfit.example.classfit.member.dto.response.MemberResponse;
+import classfit.example.classfit.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/")
+@Tag(name = "회원 컨트롤러", description = "회원 관련 API입니다.")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("sign_in")
+    @Operation(summary = "회원 가입", description = "회원가입 API 입니다.")
+    public ApiResponse<MemberResponse> signIn(@RequestBody @Valid MemberRequest request) {
+        MemberResponse memberResponse = memberService.signIn(request);
+        return ApiResponse.success(memberResponse, 200, "회원가입이 완료되었습니다.");
+    }
+}

--- a/src/main/java/classfit/example/classfit/member/domain/Member.java
+++ b/src/main/java/classfit/example/classfit/member/domain/Member.java
@@ -4,14 +4,14 @@ import classfit.example.classfit.academy.domain.Academy;
 import classfit.example.classfit.category.domain.MainClass;
 import classfit.example.classfit.common.domain.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
@@ -22,6 +22,9 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, length = 100)
     private String email;
+
+    @Column(nullable = false)
+    private String password;
 
     @Column(nullable = false, length = 30)
     private String name;
@@ -37,7 +40,7 @@ public class Member extends BaseEntity {
     private List<MainClass> mainClasses;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "academy_id", nullable = false)
+    @JoinColumn(name = "academy_id")
     private Academy academy;
 
 }

--- a/src/main/java/classfit/example/classfit/member/dto/request/MemberRequest.java
+++ b/src/main/java/classfit/example/classfit/member/dto/request/MemberRequest.java
@@ -1,0 +1,48 @@
+package classfit.example.classfit.member.dto.request;
+
+import classfit.example.classfit.member.domain.Member;
+import classfit.example.classfit.member.domain.MemberStatus;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public record MemberRequest
+    (
+        @NotBlank(message = "이름은 공백일 수 없습니다.")
+        String name,
+
+        @NotBlank(message = "전화번호는 공백일 수 없습니다.")
+        String phoneNumber,
+
+        @NotBlank(message = "이메일은 공백일 수 없습니다.")
+        @Email
+        String email,
+
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8 ~ 20자리로 입력해 주세요")
+        @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+            message = "비밀번호는 영문자 숫자를 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "비밀번호 확인란은 공백일 수 없습니다.")
+        String passwordConfirm,
+
+        @NotBlank(message = "이메일 인증번호 확인이 필요합니다.")
+        String emailToken
+
+    ) {
+    public Member toEntity(BCryptPasswordEncoder bCryptPasswordEncoder) {
+        return Member.builder()
+            .name(name())
+            .phoneNumber(phoneNumber())
+            .email(email())
+            .status(MemberStatus.ACTIVE)
+            .password(bCryptPasswordEncoder.encode(password()))
+            .build();
+    }
+
+}

--- a/src/main/java/classfit/example/classfit/member/dto/response/MemberResponse.java
+++ b/src/main/java/classfit/example/classfit/member/dto/response/MemberResponse.java
@@ -1,0 +1,21 @@
+package classfit.example.classfit.member.dto.response;
+
+import classfit.example.classfit.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public record MemberResponse
+    (
+        Long id,
+        String email
+    ) {
+
+    public static MemberResponse from(Member member) {
+        return MemberResponse.builder()
+            .id(member.getId())
+            .email(member.getEmail())
+            .build();
+    }
+}

--- a/src/main/java/classfit/example/classfit/member/service/MemberService.java
+++ b/src/main/java/classfit/example/classfit/member/service/MemberService.java
@@ -1,0 +1,43 @@
+package classfit.example.classfit.member.service;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.member.domain.Member;
+import classfit.example.classfit.member.dto.request.MemberRequest;
+import classfit.example.classfit.member.dto.response.MemberResponse;
+import classfit.example.classfit.member.repository.MemberRepository;
+import classfit.example.classfit.util.RedisUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final RedisUtil redisUtil;
+
+    public MemberResponse signIn(MemberRequest request) {
+
+        String emailToken = redisUtil.getData("Email Token : " + request.email());
+
+        if (!emailToken.equals(request.emailToken())) {
+            throw new ClassfitException("이메일 검증에 문제가 발생하였습니다. 이메일 인증을 다시 시도해 주세요", HttpStatus.NOT_FOUND);
+        }
+
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new ClassfitException("이미 사용 중인 이메일(ID) 입니다.", HttpStatus.CONFLICT);
+        }
+
+        if (!request.password().equals(request.passwordConfirm())) {
+            throw new ClassfitException("비밀번호가 일치하지 않습니다.", HttpStatus.CONFLICT);
+        }
+
+        Member member = request.toEntity(bCryptPasswordEncoder);
+
+        memberRepository.save(member);
+        return MemberResponse.from(member);
+    }
+}


### PR DESCRIPTION
# 1. 회원가입 기능 구현


![image](https://github.com/user-attachments/assets/8e7e2dca-3c70-4db9-9fe1-d1236c777d98)

---

![image](https://github.com/user-attachments/assets/6d0cde3f-68a2-4106-9322-16c646dcbe35)

---

* 이메일토큰은 이메일 검증 완료시 발급되는 JWT로, 회원가입 시 인증을 위한 용도로 사용
* 비밀번호는 영문자 포함 8 ~ 20자리 입력