### PR TITLE
[Feat] 로그아웃 기능 구현 

### DIFF
--- a/src/main/java/classfit/example/classfit/auth/controller/AuthController.java
+++ b/src/main/java/classfit/example/classfit/auth/controller/AuthController.java
@@ -1,7 +1,9 @@
 package classfit.example.classfit.auth.controller;
 
+import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.auth.service.AuthService;
 import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,5 +26,12 @@ public class AuthController {
     public ApiResponse<HttpServletResponse> reissue(HttpServletRequest request, HttpServletResponse response) {
         HttpServletResponse reissueResponse = authService.reissue(request, response);
         return ApiResponse.success(reissueResponse, 200, "재발급이 완료되었습니다");
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "로그아웃 API 입니다.")
+    public ApiResponse<String> logout(@AuthMember Member member) {
+        authService.logout(member);
+        return ApiResponse.success(null, 200, "로그아웃이 완료되었습니다.");
     }
 }

--- a/src/main/java/classfit/example/classfit/auth/service/AuthService.java
+++ b/src/main/java/classfit/example/classfit/auth/service/AuthService.java
@@ -3,6 +3,7 @@ package classfit.example.classfit.auth.service;
 import classfit.example.classfit.auth.security.jwt.JWTUtil;
 import classfit.example.classfit.common.exception.ClassfitException;
 import classfit.example.classfit.common.util.RedisUtil;
+import classfit.example.classfit.member.domain.Member;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,6 +61,18 @@ public class AuthService {
         response.setHeader("access", newAccess);
         response.addCookie(createCookie("refresh", newRefresh));
         return response;
+    }
+
+    public void logout(Member member) {
+        String redisRefreshTokenKey = "Refresh Token : " + member.getEmail();
+
+        String refreshToken = redisUtil.getData(redisRefreshTokenKey);
+
+        if (jwtUtil.isExpired(refreshToken) || refreshToken == null) {
+            throw new ClassfitException("Refresh 토큰이 유효하지 않거나 만료되었습니다..", HttpStatus.NOT_FOUND);
+        }
+
+        redisUtil.deleteData(redisRefreshTokenKey);
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/classfit/example/classfit/common/config/WebConfig.java
+++ b/src/main/java/classfit/example/classfit/common/config/WebConfig.java
@@ -1,11 +1,20 @@
 package classfit.example.classfit.common.config;
 
+import classfit.example.classfit.auth.annotation.AuthMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthMemberArgumentResolver authMemberArgumentResolver;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -13,5 +22,10 @@ public class WebConfig implements WebMvcConfigurer {
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
             .allowedHeaders("*")
             .allowCredentials(true);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authMemberArgumentResolver);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요

* 로그아웃 기능 구현 및 Refresh 토큰 삭제 로직

---

## ✅ 작업 내용

1. Redis에서 저장된 Refresh Token을 삭제하는 로그아웃 로직 구현.
   * RedisUtil의 deleteData 메서드를 활용해 토큰 제거.
   * 유효하지 않은 키나 만료된 토큰에 대한 예외 처리 추가.
2. JWT 토큰 유효성 검증 기능 추가.
   *  JwtUtil.isExpired 메서드로 만료 여부 검증.
   *  Redis 저장소에서 존재하지 않는 키를 처리하는 로직 추가.
---

## 🔗 관련 이슈
- #102

---

## 📂 변경된 파일
- AuthtController
- AuthtService
- WebConfig

---

## 📝 추가 작업 필요 여부
 - [ ] 추가적인 테스트 케이스 작성
