### PR TITLE
[Feat] 비밀번호 수정 API 

### DIFF
--- a/src/main/java/classfit/example/classfit/academy/service/AcademyService.java
+++ b/src/main/java/classfit/example/classfit/academy/service/AcademyService.java
@@ -5,7 +5,7 @@ import classfit.example.classfit.academy.dto.request.AcademyRequest;
 import classfit.example.classfit.academy.dto.response.AcademyResponse;
 import classfit.example.classfit.academy.repository.AcademyRepository;
 import classfit.example.classfit.common.exception.ClassfitException;
-import classfit.example.classfit.common.util.CodeUtil;
+import classfit.example.classfit.common.util.EmailUtil;
 import classfit.example.classfit.member.domain.Member;
 import classfit.example.classfit.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,7 +40,7 @@ public class AcademyService {
     }
 
     public String createCode() {
-        return CodeUtil.createdCode();
+        return EmailUtil.createdCode();
     }
 }
 

--- a/src/main/java/classfit/example/classfit/auth/security/filter/CustomLoginFilter.java
+++ b/src/main/java/classfit/example/classfit/auth/security/filter/CustomLoginFilter.java
@@ -59,8 +59,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
 
 
         String role = auth.getAuthority();
-        String access = jwtUtil.createJwt("access", customAuth.getEmail(), role, 1000 * 60 * 3L);                 // 3초
-        String refresh = jwtUtil.createJwt("refresh", customAuth.getEmail(), role, 1000 * 60 * 60 * 24 * 7L); //7일
+        String access = jwtUtil.createJwt("access", customAuth.getEmail(), role, 1000 * 60 * 5L);             // 5분
+        String refresh = jwtUtil.createJwt("refresh", customAuth.getEmail(), role, 1000 * 60 * 60 * 24 * 7L); // 7일
 
         addRefreshEntity(authResult.getName(), refresh, 1000 * 60 * 60 * 24 * 7L);
 
@@ -76,7 +76,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setCharacterEncoding("UTF-8");
 
         if (failed.getCause() instanceof ClassfitException classfitException) {
-            response.setStatus(classfitException.getHttpStatus().value()); // 예외에 정의된 상태 코드
+            response.setStatus(classfitException.getHttpStatus().value());
             String jsonResponse = String.format(
                 "{ \"message\": \"%s\", \"status\": %d }",
                 classfitException.getMessage(),
@@ -104,7 +104,7 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
     }
 
     private void addRefreshEntity(String email, String refresh, Long expiredMs) {
-        String redisKey = "Refresh Token : " + email;
+        String redisKey = "refresh:" + email;
         redisUtil.setDataExpire(redisKey, refresh, expiredMs);
     }
 }

--- a/src/main/java/classfit/example/classfit/auth/service/AuthService.java
+++ b/src/main/java/classfit/example/classfit/auth/service/AuthService.java
@@ -45,14 +45,14 @@ public class AuthService {
         if (!category.equals("refresh")) {
             throw new ClassfitException("invalid refresh token", HttpStatus.BAD_REQUEST);
         }
-        String redisKey = "Refresh Token : " + email;
+        String redisKey = "refresh:" + email;
         String existedToken = redisUtil.getData(redisKey);
 
         if (existedToken == null) {
             throw new ClassfitException("invalid refresh token", HttpStatus.BAD_REQUEST);
         }
 
-        String newAccess = jwtUtil.createJwt("access", email, role, 1000 * 60 * 3L);
+        String newAccess = jwtUtil.createJwt("access", email, role, 1000 * 60 * 5L);
         String newRefresh = jwtUtil.createJwt("refresh", email, role, 1000 * 60 * 60 * 24 * 7L);
 
         redisUtil.deleteData(redisKey);
@@ -64,7 +64,7 @@ public class AuthService {
     }
 
     public void logout(Member member) {
-        String redisRefreshTokenKey = "Refresh Token : " + member.getEmail();
+        String redisRefreshTokenKey = "refresh:" + member.getEmail();
 
         String refreshToken = redisUtil.getData(redisRefreshTokenKey);
 
@@ -85,7 +85,7 @@ public class AuthService {
     }
 
     private void addRefreshEntity(String email, String refresh, Long expiredMs) {
-        String redisKey = "Refresh Token : " + email;
+        String redisKey = "refresh:" + email;
         redisUtil.setDataExpire(redisKey, refresh, expiredMs);
     }
 }

--- a/src/main/java/classfit/example/classfit/common/util/EmailUtil.java
+++ b/src/main/java/classfit/example/classfit/common/util/EmailUtil.java
@@ -2,7 +2,7 @@ package classfit.example.classfit.common.util;
 
 import java.util.Random;
 
-public class CodeUtil {
+public class EmailUtil {
 
     public static String createdCode() {
         int leftLimit = 48;             // number '0'
@@ -15,5 +15,10 @@ public class CodeUtil {
             .limit(targetStringLength)
             .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
             .toString();
+    }
+
+    public static String splitEmail(String email) {
+        String[] splitEmail = email.split("@");
+        return splitEmail[0];
     }
 }

--- a/src/main/java/classfit/example/classfit/common/util/RedisUtil.java
+++ b/src/main/java/classfit/example/classfit/common/util/RedisUtil.java
@@ -1,8 +1,11 @@
 package classfit.example.classfit.common.util;
 
+import classfit.example.classfit.common.exception.ClassfitException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
@@ -13,19 +16,40 @@ public class RedisUtil {
 
     private final StringRedisTemplate redisTemplate;
 
-
     public String getData(String key) {
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        return valueOperations.get(key);
+        try {
+            ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+            String value = valueOperations.get(key);
+
+            if (value == null) {
+                throw new ClassfitException("해당 키에 대한 값이 존재하지 않습니다: " + key, HttpStatus.NOT_FOUND);
+            }
+
+            return value;
+        } catch (DataAccessException e) {
+            throw new ClassfitException("Redis 서버에서 데이터를 가져오는 중 오류가 발생했습니다: ", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     public void setDataExpire(String key, String value, long duration) {
-        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        Duration expireDuration = Duration.ofSeconds(duration);
-        valueOperations.set(key, value, expireDuration);
+        try {
+            ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+            Duration expireDuration = Duration.ofSeconds(duration);
+            valueOperations.set(key, value, expireDuration);
+        } catch (DataAccessException e) {
+            throw new ClassfitException("Redis 서버에 데이터를 설정하는 중 오류가 발생했습니다: ", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     public void deleteData(String key) {
-        redisTemplate.delete(key);
+        try {
+            Boolean result = redisTemplate.delete(key);
+
+            if (Boolean.FALSE.equals(result)) {
+                throw new ClassfitException("삭제 요청 실패: 키가 존재하지 않거나 삭제되지 않았습니다: ", HttpStatus.NOT_FOUND);
+            }
+        } catch (DataAccessException e) {
+            throw new ClassfitException("Redis 서버에서 데이터를 삭제하는 중 오류가 발생했습니다: ", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
+++ b/src/main/java/classfit/example/classfit/mail/controller/EmailAuthController.java
@@ -15,8 +15,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/v1/mail")
+@RequiredArgsConstructor
 @Tag(name = "이메일 API", description = "이메일 관련 API")
 public class EmailAuthController {
 

--- a/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthPurpose.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthPurpose.java
@@ -1,0 +1,6 @@
+package classfit.example.classfit.mail.dto.request;
+
+public enum EmailAuthPurpose {
+    SIGN_IN,
+    PASSWORD_RESET
+}

--- a/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthRequest.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthRequest.java
@@ -1,12 +1,17 @@
 package classfit.example.classfit.mail.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "이메일 전송 DTO")
 public record EmailAuthRequest
     (
         @NotBlank(message = "이메일을 입력해 주세요")
         @Email(message = "올바르지 않은 이메일 형식입니다.")
-        String email
+        String email,
+
+        @Schema(description = "회원가입 >> SIGN_IN , 비밀번호 찾기 >> PASSWORD_RESET")
+        EmailAuthPurpose purpose
     ) {
 }

--- a/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthVerifyRequest.java
+++ b/src/main/java/classfit/example/classfit/mail/dto/request/EmailAuthVerifyRequest.java
@@ -1,8 +1,10 @@
 package classfit.example.classfit.mail.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "이메일 인증코드 검증 DTO")
 public record EmailAuthVerifyRequest
     (
         @NotBlank(message = "이메일을 입력해 주세요")
@@ -10,6 +12,9 @@ public record EmailAuthVerifyRequest
         String email,
 
         @NotBlank(message = "인증 코드는 필수 입력입니다.")
-        String code
+        String code,
+
+        @Schema(description = "회원가입 >> SIGN_IN , 비밀번호 찾기 >> PASSWORD_RESET")
+        EmailAuthPurpose purpose
     ) {
 }

--- a/src/main/java/classfit/example/classfit/member/controller/MemberController.java
+++ b/src/main/java/classfit/example/classfit/member/controller/MemberController.java
@@ -30,7 +30,7 @@ public class MemberController {
     }
 
     @PostMapping("/password")
-    @Operation(summary = "비밀번호 찾기", description = "특정 회원의 비밀번호 수정 API 입니다.")
+    @Operation(summary = "비밀번호 수정", description = "특정 회원의 비밀번호 수정 API 입니다.")
     public ApiResponse<String> updatePassword(@RequestBody @Valid MemberPasswordRequest request) {
         memberService.updatePassword(request);
         return ApiResponse.success(null, 200, "비밀번호가 변경되었습니다.");

--- a/src/main/java/classfit/example/classfit/member/controller/MemberController.java
+++ b/src/main/java/classfit/example/classfit/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package classfit.example.classfit.member.controller;
 
 import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.member.dto.request.MemberPasswordRequest;
 import classfit.example.classfit.member.dto.request.MemberRequest;
 import classfit.example.classfit.member.dto.response.MemberResponse;
 import classfit.example.classfit.member.service.MemberService;
@@ -26,5 +27,12 @@ public class MemberController {
     public ApiResponse<MemberResponse> signIn(@RequestBody @Valid MemberRequest request) {
         MemberResponse memberResponse = memberService.signIn(request);
         return ApiResponse.success(memberResponse, 200, "회원가입이 완료되었습니다.");
+    }
+
+    @PostMapping("/password")
+    @Operation(summary = "비밀번호 찾기", description = "특정 회원의 비밀번호 수정 API 입니다.")
+    public ApiResponse<String> updatePassword(@RequestBody @Valid MemberPasswordRequest request) {
+        memberService.updatePassword(request);
+        return ApiResponse.success(null, 200, "비밀번호가 변경되었습니다.");
     }
 }

--- a/src/main/java/classfit/example/classfit/member/domain/Member.java
+++ b/src/main/java/classfit/example/classfit/member/domain/Member.java
@@ -54,4 +54,8 @@ public class Member extends BaseEntity {
     public void updateRole(String admin) {
         this.role = admin;
     }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/classfit/example/classfit/member/dto/request/MemberPasswordRequest.java
+++ b/src/main/java/classfit/example/classfit/member/dto/request/MemberPasswordRequest.java
@@ -1,0 +1,29 @@
+package classfit.example.classfit.member.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberPasswordRequest
+    (
+
+        @NotBlank(message = "이메일은 공백일 수 없습니다.")
+        @Email(message = "형식이 올바르지 않습니다.")
+        String email,
+        
+        @NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8 ~ 20자리로 입력해 주세요")
+        @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$",
+            message = "비밀번호는 영문자 숫자를 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "비밀번호 확인란은 공백일 수 없습니다.")
+        String passwordConfirm,
+
+        @NotBlank(message = "이메일 인증번호 확인이 필요합니다.")
+        String emailToken
+    ) {
+}

--- a/src/main/java/classfit/example/classfit/member/service/MemberService.java
+++ b/src/main/java/classfit/example/classfit/member/service/MemberService.java
@@ -1,8 +1,11 @@
 package classfit.example.classfit.member.service;
 
 import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.common.util.EmailUtil;
 import classfit.example.classfit.common.util.RedisUtil;
+import classfit.example.classfit.mail.dto.request.EmailAuthPurpose;
 import classfit.example.classfit.member.domain.Member;
+import classfit.example.classfit.member.dto.request.MemberPasswordRequest;
 import classfit.example.classfit.member.dto.request.MemberRequest;
 import classfit.example.classfit.member.dto.response.MemberResponse;
 import classfit.example.classfit.member.repository.MemberRepository;
@@ -23,7 +26,7 @@ public class MemberService {
     @Transactional
     public MemberResponse signIn(MemberRequest request) {
 
-        String emailToken = redisUtil.getData("Email Token : " + request.email());
+        String emailToken = redisUtil.getData(EmailAuthPurpose.SIGN_IN + ":" + EmailUtil.splitEmail(request.email()) + ":token");
 
         if (!emailToken.equals(request.emailToken())) {
             throw new ClassfitException("이메일 검증에 문제가 발생하였습니다. 이메일 인증을 다시 시도해 주세요", HttpStatus.NOT_FOUND);
@@ -41,5 +44,22 @@ public class MemberService {
 
         memberRepository.save(member);
         return MemberResponse.from(member);
+    }
+
+    @Transactional
+    public void updatePassword(MemberPasswordRequest request) {
+        String emailToken = redisUtil.getData(EmailAuthPurpose.PASSWORD_RESET + ":" + EmailUtil.splitEmail(request.email()) + ":token");
+
+        if (!emailToken.equals(request.emailToken())) {
+            throw new ClassfitException("이메일 검증에 문제가 발생하였습니다. 이메일 인증을 다시 시도해 주세요", HttpStatus.NOT_FOUND);
+        }
+
+        if (!request.password().equals(request.passwordConfirm())) {
+            throw new ClassfitException("비밀번호가 일치하지 않습니다.", HttpStatus.CONFLICT);
+        }
+
+        Member findMember = memberRepository.findByEmail(request.email()).orElseThrow(() -> new ClassfitException("존재하지 않는 계정입니다.", HttpStatus.NOT_FOUND));
+
+        findMember.updatePassword(bCryptPasswordEncoder.encode(request.password()));
     }
 }

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -5,11 +5,11 @@
     <h1 style="color: black"> 안녕하세요.</h1>
     <h1 style="color: black"> ClassFit 입니다.</h1>
     <br>
-    <p style="color: black"> 아래 코드를 회원가입 창으로 돌아가 입력해주세요.</p>
+    <p style="color: black"> 아래 코드를 화면으로 돌아가 입력해주세요.</p>
     <br>
 
     <div align="center" style="border:1px solid black; padding:15px; font-family:verdana;">
-        <h3> 회원가입 인증 코드 </h3>
+        <h3> 인증 코드 </h3>
         <div style="font-size:130%; color:darkred" th:text="${code}"></div>
     </div>
     <br/>


### PR DESCRIPTION
## 📌 작업 개요

* 사용자의 이메일 인증을 통해 비밀번호 변경 기능을 추가

---

## ✅ 작업 내용

1. 이메일 인증 코드로 사용자 확인
2. 비밀번호 수정
3.  Redis 키 네이밍 수정
4. 이메일 검증 용도 ENUM 추가
5. 비밀번호 수정 DTO 추가

![image](https://github.com/user-attachments/assets/a117625f-6005-43e6-8e03-3e4341da290c)

---

## 🔗 관련 이슈
- #104

---

## 📂 변경된 파일
- AuthService
- RedisUtil
- EmailAuthController
- EmailAuthPurpose (+)
- MemberPasswordRequest (+)

  . . .

---

## 📝 추가 작업 필요 여부
