### PR TITLE
[Feat] 마이페이지 관련 API 구현

### DIFF
--- a/src/main/java/classfit/example/classfit/member/controller/MemberController.java
+++ b/src/main/java/classfit/example/classfit/member/controller/MemberController.java
@@ -1,18 +1,18 @@
 package classfit.example.classfit.member.controller;
 
+import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.member.domain.Member;
 import classfit.example.classfit.member.dto.request.MemberPasswordRequest;
 import classfit.example.classfit.member.dto.request.MemberRequest;
+import classfit.example.classfit.member.dto.response.MemberInfoResponse;
 import classfit.example.classfit.member.dto.response.MemberResponse;
 import classfit.example.classfit.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -34,5 +34,12 @@ public class MemberController {
     public ApiResponse<String> updatePassword(@RequestBody @Valid MemberPasswordRequest request) {
         memberService.updatePassword(request);
         return ApiResponse.success(null, 200, "비밀번호가 변경되었습니다.");
+    }
+
+    @GetMapping("/mypage")
+    @Operation(summary = "회원정보 조회", description = "마이페이지 API 입니다.")
+    public ApiResponse<MemberInfoResponse> myPage(@AuthMember Member member) {
+        MemberInfoResponse memberInfoResponse = memberService.myPage(member);
+        return ApiResponse.success(memberInfoResponse, 200, "SUCCESS");
     }
 }

--- a/src/main/java/classfit/example/classfit/member/controller/MemberController.java
+++ b/src/main/java/classfit/example/classfit/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import classfit.example.classfit.common.ApiResponse;
 import classfit.example.classfit.member.domain.Member;
 import classfit.example.classfit.member.dto.request.MemberPasswordRequest;
 import classfit.example.classfit.member.dto.request.MemberRequest;
+import classfit.example.classfit.member.dto.request.MemberUpdateInfoRequest;
 import classfit.example.classfit.member.dto.response.MemberInfoResponse;
 import classfit.example.classfit.member.dto.response.MemberResponse;
 import classfit.example.classfit.member.service.MemberService;
@@ -40,6 +41,13 @@ public class MemberController {
     @Operation(summary = "회원정보 조회", description = "마이페이지 API 입니다.")
     public ApiResponse<MemberInfoResponse> myPage(@AuthMember Member member) {
         MemberInfoResponse memberInfoResponse = memberService.myPage(member);
+        return ApiResponse.success(memberInfoResponse, 200, "SUCCESS");
+    }
+
+    @PostMapping("/mypage")
+    @Operation(summary = "회원정보 수정", description = "회원 정보 수정하는 API 입니다.")
+    public ApiResponse<MemberInfoResponse> updateMyPage(@AuthMember Member member, @RequestBody MemberUpdateInfoRequest request) {
+        MemberInfoResponse memberInfoResponse = memberService.updateMyPage(member, request);
         return ApiResponse.success(memberInfoResponse, 200, "SUCCESS");
     }
 }

--- a/src/main/java/classfit/example/classfit/member/domain/Member.java
+++ b/src/main/java/classfit/example/classfit/member/domain/Member.java
@@ -6,6 +6,7 @@ import classfit.example.classfit.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
@@ -38,6 +39,12 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     private MemberStatus status;
+
+    @Column(length = 30)
+    private LocalDate birthDate;
+
+    @Column(length = 30)
+    private String subject;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MainClass> mainClasses;

--- a/src/main/java/classfit/example/classfit/member/domain/Member.java
+++ b/src/main/java/classfit/example/classfit/member/domain/Member.java
@@ -3,6 +3,7 @@ package classfit.example.classfit.member.domain;
 import classfit.example.classfit.academy.domain.Academy;
 import classfit.example.classfit.category.domain.MainClass;
 import classfit.example.classfit.common.domain.BaseEntity;
+import classfit.example.classfit.member.dto.request.MemberUpdateInfoRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -63,5 +64,10 @@ public class Member extends BaseEntity {
 
     public void updatePassword(String password) {
         this.password = password;
+    }
+
+    public void updateInfo(MemberUpdateInfoRequest request) {
+        this.birthDate = request.birth();
+        this.subject = request.subject();
     }
 }

--- a/src/main/java/classfit/example/classfit/member/dto/request/MemberUpdateInfoRequest.java
+++ b/src/main/java/classfit/example/classfit/member/dto/request/MemberUpdateInfoRequest.java
@@ -1,0 +1,17 @@
+package classfit.example.classfit.member.dto.request;
+
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record MemberUpdateInfoRequest
+    (
+        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @Past LocalDate birth,
+
+        @Size(max = 30)
+        String subject
+    ) {
+}

--- a/src/main/java/classfit/example/classfit/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/classfit/example/classfit/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,31 @@
+package classfit.example.classfit.member.dto.response;
+
+import classfit.example.classfit.member.domain.Member;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MemberInfoResponse
+    (
+        String name,
+        
+        String phoneNumber,
+
+        LocalDate birth,
+
+        String email,
+
+        String subject
+    ) {
+
+    public static MemberInfoResponse from(Member member) {
+        return MemberInfoResponse.builder()
+            .name(member.getName())
+            .phoneNumber(member.getPhoneNumber())
+            .birth(member.getBirthDate())
+            .subject(member.getSubject())
+            .email(member.getEmail())
+            .build();
+    }
+}

--- a/src/main/java/classfit/example/classfit/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/classfit/example/classfit/member/dto/response/MemberInfoResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 public record MemberInfoResponse
     (
         String name,
-        
+
         String phoneNumber,
 
         LocalDate birth,

--- a/src/main/java/classfit/example/classfit/member/service/MemberService.java
+++ b/src/main/java/classfit/example/classfit/member/service/MemberService.java
@@ -6,6 +6,7 @@ import classfit.example.classfit.mail.dto.request.EmailPurpose;
 import classfit.example.classfit.member.domain.Member;
 import classfit.example.classfit.member.dto.request.MemberPasswordRequest;
 import classfit.example.classfit.member.dto.request.MemberRequest;
+import classfit.example.classfit.member.dto.request.MemberUpdateInfoRequest;
 import classfit.example.classfit.member.dto.response.AcademyMemberResponse;
 import classfit.example.classfit.member.dto.response.MemberInfoResponse;
 import classfit.example.classfit.member.dto.response.MemberResponse;
@@ -76,6 +77,12 @@ public class MemberService {
 
     @Transactional(readOnly = true)
     public MemberInfoResponse myPage(Member member) {
+        return MemberInfoResponse.from(member);
+    }
+
+    @Transactional
+    public MemberInfoResponse updateMyPage(Member member, MemberUpdateInfoRequest request) {
+        member.updateInfo(request);
         return MemberInfoResponse.from(member);
     }
 


### PR DESCRIPTION
## 📌 작업 개요

* 로그인한 사용자의 정보를 조회하는 기능 구

---

## ✅ 작업 내용

### - **개인 정보 조회 API**
 
![image](https://github.com/user-attachments/assets/4916610f-3250-4416-9722-dd9e875c80fc)

### - **개인 정보 수정 API**

![image](https://github.com/user-attachments/assets/8894b9c5-bd9c-4cfa-babb-4dcbbfdabaaa)


-  **Member Entity 필드 추가**
   - 마이페이지에 필요한 정보를 저장하기 위해 Member Entity에 새로운 필드를 추가



---

## 🔗 관련 이슈
- #137

---

## 📂 변경된 파일
- MemberController
- MemberService
- Member
- Request/Response DTO


---

## 📝 추가 작업 필요 여부
- [ ] example
