### PR TITLE
 [Feat] 드라이브 휴지통 기능 및 삭제 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 ### Specific files to ignore ###
 src/main/resources/application.properties
 src/main/resources/application-local.properties
+
+log

--- a/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
+++ b/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
@@ -1,0 +1,35 @@
+package classfit.example.classfit.common.util;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.member.domain.Member;
+import org.springframework.http.HttpStatus;
+
+import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
+import static classfit.example.classfit.drive.domain.DriveType.SHARED;
+
+public class DriveUtil {
+
+    public static String generatedOriginPath(Member member, DriveType driveType, String folderPath, String fileName) {
+        String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
+
+        if (driveType == PERSONAL) {
+            return String.format("personal/%d/%s%s", member.getId(), fullFolderPath, fileName);
+        } else if (driveType == SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("shared/%d/%s%s", academyId, fullFolderPath, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+
+    public static String generateTrashPath(Member member, DriveType driveType, String fileName) {
+
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("trash/personal/%d/%s", member.getId(), fileName);
+        } else if (driveType == DriveType.SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("trash/shared/%d/%s", academyId, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
+++ b/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
@@ -2,8 +2,14 @@ package classfit.example.classfit.common.util;
 
 import classfit.example.classfit.common.exception.ClassfitException;
 import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.drive.domain.FileType;
 import classfit.example.classfit.member.domain.Member;
+import com.amazonaws.services.s3.model.Tag;
 import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
 import static classfit.example.classfit.drive.domain.DriveType.SHARED;
@@ -24,12 +30,51 @@ public class DriveUtil {
 
     public static String generateTrashPath(Member member, DriveType driveType, String fileName) {
 
+        String basePath;
+
         if (driveType == DriveType.PERSONAL) {
-            return String.format("trash/personal/%d/%s", member.getId(), fileName);
+            basePath = String.format("trash/personal/%d/", member.getId());
         } else if (driveType == DriveType.SHARED) {
             Long academyId = member.getAcademy().getId();
-            return String.format("trash/shared/%d/%s", academyId, fileName);
+            basePath = String.format("trash/shared/%d/", academyId);
+        } else {
+            throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
         }
-        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+
+        return (fileName != null && !fileName.trim().isEmpty()) ? basePath + fileName : basePath;
+    }
+
+    public static String extractTags(List<Tag> tags, String tagKey) {
+        return tags.stream()
+            .filter(tag -> tag.getKey().equals(tagKey))
+            .map(Tag::getValue)
+            .findFirst()
+            .orElse("");
+    }
+
+    public static LocalDateTime parseUploadedAt(String uploadedAtStr) {
+        return (uploadedAtStr == null || uploadedAtStr.isBlank())
+            ? LocalDateTime.now()
+            : LocalDateTime.parse(uploadedAtStr, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    public static FileType getFileType(String fileName) {
+        int dotIndex = fileName.lastIndexOf(".");
+        if (dotIndex != -1 && dotIndex < fileName.length() - 1) {
+            String extension = fileName.substring(dotIndex + 1).toLowerCase();
+            return FileType.getFileTypeByExtension(extension);
+        }
+        return FileType.UNKNOWN;
+    }
+
+    public static String formatFileSize(long sizeInBytes) {
+        double sizeInKB = sizeInBytes / 1024.0;
+        if (sizeInKB >= 1024) {
+            // 1MB 이상이면 MB 단위로 표시
+            double sizeInMB = sizeInKB / 1024.0;
+            return String.format("%.1f MB", sizeInMB); // 소수점 한 자리까지 MB로 표시
+        }
+        // 1MB 미만이면 KB 단위로 표시
+        return String.format("%.1f KB", sizeInKB); // 소수점 한 자리까지 KB로 표시
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveController.java
@@ -19,7 +19,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -65,7 +64,7 @@ public class DriveController {
     @Operation(summary = "파일 다운로드", description = "파일 다운로드 API 입니다.")
     public ResponseEntity<InputStreamResource> downloadFile(
         @RequestParam("fileName") String fileName
-    ) throws UnsupportedEncodingException {
+    ) {
         InputStreamResource resource = driveDownloadService.downloadFile(fileName);
         String fileExtension = driveDownloadService.getFileExtension(fileName);
         String contentType = driveDownloadService.getContentType(fileExtension);

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveController.java
@@ -12,27 +12,24 @@ import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/drive")
 @Tag(name = "드라이브 컨트롤러", description = "드라이브 관련 API입니다.")
 public class DriveController {
+
     private final DriveGetService driveGetService;
     private final DriveUploadService driveUploadService;
     private final DriveDownloadService driveDownloadService;
@@ -73,7 +70,7 @@ public class DriveController {
         String fileExtension = driveDownloadService.getFileExtension(fileName);
         String contentType = driveDownloadService.getContentType(fileExtension);
 
-        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8.toString());
+        String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + encodedFileName + "\"");
         headers.add(HttpHeaders.CONTENT_TYPE, contentType);

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -1,0 +1,35 @@
+package classfit.example.classfit.drive.controller;
+
+import classfit.example.classfit.auth.annotation.AuthMember;
+import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.drive.service.DriveTrashService;
+import classfit.example.classfit.member.domain.Member;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/drive")
+@Tag(name = "드라이브 휴지통 컨트롤러", description = "드라이브 휴지통 관련 API입니다.")
+public class DriveTrashController {
+
+    private final DriveTrashService driveTrashService;
+
+    @PostMapping("/trash")
+    public ApiResponse<String> moveToTrash(
+        @AuthMember Member member,
+        @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
+        @RequestParam DriveType driveType,
+        @Parameter(description = "파일이름 및 폴더(folder/), 폴더 입력 시 하위 목록까지 휴지통으로 이동합니다.")
+        @RequestParam String fileName
+    ) {
+        String trashPath = driveTrashService.moveToTrash(member, driveType, fileName);
+        return ApiResponse.success(trashPath, 200, "휴지통 이동 완료");
+    }
+}

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -3,6 +3,7 @@ package classfit.example.classfit.drive.controller;
 import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
 import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.drive.service.DriveRestoreService;
 import classfit.example.classfit.drive.service.DriveTrashService;
 import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,18 +21,31 @@ import org.springframework.web.bind.annotation.RestController;
 public class DriveTrashController {
 
     private final DriveTrashService driveTrashService;
+    private final DriveRestoreService driveRestoreService;
 
     @PostMapping("/trash")
     public ApiResponse<String> moveToTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
-        @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더에 지정됩니다.")
+        @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더로 지정됩니다.")
         @RequestParam(required = false, defaultValue = "") String folderPath,
         @Parameter(description = "파일이름")
         @RequestParam String fileName
     ) {
         String trashPath = driveTrashService.moveToTrash(member, driveType, folderPath, fileName);
         return ApiResponse.success(trashPath, 200, "휴지통 이동 완료");
+    }
+
+    @PostMapping("/trash/restore")
+    public ApiResponse<String> restoreFromTrash(
+        @AuthMember Member member,
+        @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
+        @RequestParam DriveType driveType,
+        @Parameter(description = "파일 이름")
+        @RequestParam String fileName
+    ) {
+        String restoredPath = driveRestoreService.restoreFromTrash(member, driveType, fileName);
+        return ApiResponse.success(restoredPath, 200, "복원 성공");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -3,6 +3,7 @@ package classfit.example.classfit.drive.controller;
 import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
 import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.drive.dto.response.FileResponse;
 import classfit.example.classfit.drive.service.DriveDeleteService;
 import classfit.example.classfit.drive.service.DriveRestoreService;
 import classfit.example.classfit.drive.service.DriveTrashService;
@@ -24,6 +25,16 @@ public class DriveTrashController {
     private final DriveTrashService driveTrashService;
     private final DriveRestoreService driveRestoreService;
     private final DriveDeleteService driveDeleteService;
+
+    @GetMapping("/trash")
+    public ApiResponse<List<FileResponse>> trashList(
+        @AuthMember Member member,
+        @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
+        @RequestParam DriveType driveType
+    ) {
+        List<FileResponse> filesFromTrash = driveTrashService.getFilesFromTrash(member, driveType);
+        return ApiResponse.success(filesFromTrash, 200, "조회 성공");
+    }
 
     @PostMapping("/trash")
     public ApiResponse<List<String>> moveToTrash(

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -26,10 +26,12 @@ public class DriveTrashController {
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
-        @Parameter(description = "파일이름 및 폴더(folder/), 폴더 입력 시 하위 목록까지 휴지통으로 이동합니다.")
+        @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더에 지정됩니다.")
+        @RequestParam(required = false, defaultValue = "") String folderPath,
+        @Parameter(description = "파일이름")
         @RequestParam String fileName
     ) {
-        String trashPath = driveTrashService.moveToTrash(member, driveType, fileName);
+        String trashPath = driveTrashService.moveToTrash(member, driveType, folderPath, fileName);
         return ApiResponse.success(trashPath, 200, "휴지통 이동 완료");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -26,17 +26,17 @@ public class DriveTrashController {
     private final DriveDeleteService driveDeleteService;
 
     @PostMapping("/trash")
-    public ApiResponse<String> moveToTrash(
+    public ApiResponse<List<String>> moveToTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
         @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더로 지정됩니다.")
         @RequestParam(required = false, defaultValue = "") String folderPath,
-        @Parameter(description = "파일이름")
-        @RequestParam String fileName
+        @Parameter(description = "파일 이름")
+        @RequestParam List<String> fileNames
     ) {
-        String trashPath = driveTrashService.moveToTrash(member, driveType, folderPath, fileName);
-        return ApiResponse.success(trashPath, 200, "휴지통 이동 완료");
+        List<String> trashPathList = driveTrashService.moveToTrash(member, driveType, folderPath, fileNames);
+        return ApiResponse.success(trashPathList, 200, "휴지통 이동 완료");
     }
 
     @PostMapping("/trash/restore")

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -3,16 +3,17 @@ package classfit.example.classfit.drive.controller;
 import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
 import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.drive.service.DriveDeleteService;
 import classfit.example.classfit.drive.service.DriveRestoreService;
 import classfit.example.classfit.drive.service.DriveTrashService;
 import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class DriveTrashController {
 
     private final DriveTrashService driveTrashService;
     private final DriveRestoreService driveRestoreService;
+    private final DriveDeleteService driveDeleteService;
 
     @PostMapping("/trash")
     public ApiResponse<String> moveToTrash(
@@ -47,5 +49,17 @@ public class DriveTrashController {
     ) {
         String restoredPath = driveRestoreService.restoreFromTrash(member, driveType, fileName);
         return ApiResponse.success(restoredPath, 200, "복원 성공");
+    }
+
+    @DeleteMapping("/trash")
+    public ApiResponse<Nullable> deleteFromTrash(
+        @AuthMember Member member,
+        @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
+        @RequestParam DriveType driveType,
+        @Parameter(description = "파일 이름")
+        @RequestParam List<String> fileName
+    ) {
+        driveDeleteService.deleteFromTrash(member, driveType, fileName);
+        return ApiResponse.success(null, 200, "삭제 성공");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -40,15 +40,15 @@ public class DriveTrashController {
     }
 
     @PostMapping("/trash/restore")
-    public ApiResponse<String> restoreFromTrash(
+    public ApiResponse<List<String>> restoreFromTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
         @Parameter(description = "파일 이름")
-        @RequestParam String fileName
+        @RequestParam List<String> fileNames
     ) {
-        String restoredPath = driveRestoreService.restoreFromTrash(member, driveType, fileName);
-        return ApiResponse.success(restoredPath, 200, "복원 성공");
+        List<String> restorePathList = driveRestoreService.restoreFromTrash(member, driveType, fileNames);
+        return ApiResponse.success(restorePathList, 200, "복원 성공");
     }
 
     @DeleteMapping("/trash")

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -8,6 +8,7 @@ import classfit.example.classfit.drive.service.DriveDeleteService;
 import classfit.example.classfit.drive.service.DriveRestoreService;
 import classfit.example.classfit.drive.service.DriveTrashService;
 import classfit.example.classfit.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
@@ -27,6 +28,7 @@ public class DriveTrashController {
     private final DriveDeleteService driveDeleteService;
 
     @GetMapping("/trash")
+    @Operation(summary = "휴지통 조회", description = "휴지통 조회 API 입니다.")
     public ApiResponse<List<FileResponse>> trashList(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
@@ -37,6 +39,7 @@ public class DriveTrashController {
     }
 
     @PostMapping("/trash")
+    @Operation(summary = "휴지통 이동", description = "휴지통 이동 API 입니다.")
     public ApiResponse<List<String>> moveToTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
@@ -51,6 +54,7 @@ public class DriveTrashController {
     }
 
     @PostMapping("/trash/restore")
+    @Operation(summary = "휴지통 복원", description = "휴지통 복원 API 입니다.")
     public ApiResponse<List<String>> restoreFromTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
@@ -63,6 +67,7 @@ public class DriveTrashController {
     }
 
     @DeleteMapping("/trash")
+    @Operation(summary = "휴지통 영구삭제", description = "휴지통 영구삭제 API 입니다.")
     public ApiResponse<Nullable> deleteFromTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")

--- a/src/main/java/classfit/example/classfit/drive/domain/FileType.java
+++ b/src/main/java/classfit/example/classfit/drive/domain/FileType.java
@@ -9,7 +9,8 @@ public enum FileType {
     VIDEO("mp4", "avi", "mkv", "mov", "wmv", "flv"),
     AUDIO("mp3", "wav", "aac", "flac", "ogg"),
     ARCHIVE("zip", "tar", "gz", "rar", "7z"),
-    OTHER("other");
+    OTHER("other"),
+    UNKNOWN("");
 
     private final List<String> extensions;
 

--- a/src/main/java/classfit/example/classfit/drive/dto/response/FileResponse.java
+++ b/src/main/java/classfit/example/classfit/drive/dto/response/FileResponse.java
@@ -1,0 +1,17 @@
+package classfit.example.classfit.drive.dto.response;
+
+import classfit.example.classfit.drive.domain.FileType;
+
+import java.time.LocalDateTime;
+
+public record FileResponse
+    (
+        FileType fileType,
+        String fileName,
+        String fileSize,
+        String fileUrl,
+        String folderPath,
+        String uploadedBy,
+        LocalDateTime uploadedAt
+    ) {
+}

--- a/src/main/java/classfit/example/classfit/drive/service/DriveDeleteService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveDeleteService.java
@@ -1,0 +1,43 @@
+package classfit.example.classfit.drive.service;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.member.domain.Member;
+import com.amazonaws.services.s3.AmazonS3;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DriveDeleteService {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public void deleteFromTrash(Member member, DriveType driveType, List<String> fileNames) {
+        for (String fileName : fileNames) {
+            try {
+                String trashPath = generateTrashPath(member, driveType, fileName);
+                amazonS3.deleteObject(bucketName, trashPath);
+            } catch (Exception e) {
+                System.err.println("파일 삭제 중 오류 발생: " + fileName);
+            }
+        }
+    }
+
+    private String generateTrashPath(Member member, DriveType driveType, String fileName) {
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("trash/personal/%d/%s", member.getId(), fileName);
+        } else if (driveType == DriveType.SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("trash/shared/%d/%s", academyId, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+}
+

--- a/src/main/java/classfit/example/classfit/drive/service/DriveFolderService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveFolderService.java
@@ -1,26 +1,21 @@
 package classfit.example.classfit.drive.service;
 
-import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
-
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.ObjectTagging;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
-import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+
+import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +35,7 @@ public class DriveFolderService {
 
         InputStream emptyContent = new ByteArrayInputStream(new byte[0]);
         amazonS3.putObject(new PutObjectRequest(bucketName, fullFolderPath, emptyContent, metadata));
-        addTagsToS3Object(fullFolderPath, member);
+        addUploadTagsToS3Object(fullFolderPath, member);
         return fullFolderPath;
     }
 
@@ -73,7 +68,7 @@ public class DriveFolderService {
         return basePath + (folderPath.isEmpty() ? "" : folderPath + "/") + folderName + "/";
     }
 
-    private void addTagsToS3Object(String objectKey, Member member) {
+    private void addUploadTagsToS3Object(String objectKey, Member member) {
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
         List<Tag> tags = List.of(

--- a/src/main/java/classfit/example/classfit/drive/service/DriveGetService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveGetService.java
@@ -1,5 +1,6 @@
 package classfit.example.classfit.drive.service;
 
+import classfit.example.classfit.common.exception.ClassfitException;
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.drive.domain.FileType;
 import classfit.example.classfit.drive.dto.response.FileInfo;
@@ -8,6 +9,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.text.Normalizer;
@@ -59,7 +61,7 @@ public class DriveGetService {
                 basePrefix = "shared/" + academyId + "/";
                 break;
             default:
-                throw new IllegalArgumentException("유효하지 않은 드라이브 타입");
+                throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
         }
         if (folderPath == null || folderPath.trim().isEmpty()) {
             return basePrefix;
@@ -120,7 +122,7 @@ public class DriveGetService {
         } else if (driveType == DriveType.SHARED) {
             basePrefix = "shared/" + member.getAcademy().getId();
         } else {
-            throw new IllegalArgumentException("지원하지 않는 드라이브 타입입니다.");
+            throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
         }
         return basePrefix + "/";
     }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
@@ -1,0 +1,67 @@
+package classfit.example.classfit.drive.service;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.member.domain.Member;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.GetObjectTaggingResult;
+import com.amazonaws.services.s3.model.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DriveRestoreService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String restoreFromTrash(Member member, DriveType driveType, String fileName) {
+        String trashPath = generateTrashPath(member, driveType, fileName);
+
+        GetObjectTaggingRequest taggingRequest = new GetObjectTaggingRequest(bucketName, trashPath);
+        GetObjectTaggingResult taggingResult = amazonS3.getObjectTagging(taggingRequest);
+
+        Map<String, String> tagMap = taggingResult.getTagSet().stream()
+            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+
+        String folderPath = tagMap.getOrDefault("folderPath", "");
+        String restoredPath = generateOriginalPath(member, driveType, folderPath, fileName);
+
+        CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, trashPath, bucketName, restoredPath);
+        amazonS3.copyObject(copyRequest);
+
+        amazonS3.deleteObject(bucketName, trashPath);
+        return restoredPath;
+    }
+
+    private String generateTrashPath(Member member, DriveType driveType, String fileName) {
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("trash/personal/%d/%s", member.getId(), fileName);
+        } else if (driveType == DriveType.SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("trash/shared/%d/%s", academyId, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+
+    private String generateOriginalPath(Member member, DriveType driveType, String folderPath, String fileName) {
+        String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath : "";
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("personal/%d/%s%s", member.getId(), fullFolderPath, fileName);
+        } else if (driveType == DriveType.SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("shared/%d/%s%s", academyId, fullFolderPath, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+}

--- a/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
@@ -35,7 +35,7 @@ public class DriveRestoreService {
             .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
 
         String folderPath = tagMap.getOrDefault("folderPath", "");
-        String restoredPath = generateOriginalPath(member, driveType, folderPath, fileName);
+        String restoredPath = generateSourcePath(member, driveType, folderPath, fileName);
 
         CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, trashPath, bucketName, restoredPath);
         amazonS3.copyObject(copyRequest);
@@ -54,8 +54,8 @@ public class DriveRestoreService {
         throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
     }
 
-    private String generateOriginalPath(Member member, DriveType driveType, String folderPath, String fileName) {
-        String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath : "";
+    private String generateSourcePath(Member member, DriveType driveType, String folderPath, String fileName) {
+        String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
         if (driveType == DriveType.PERSONAL) {
             return String.format("personal/%d/%s%s", member.getId(), fullFolderPath, fileName);
         } else if (driveType == DriveType.SHARED) {

--- a/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
@@ -1,13 +1,12 @@
 package classfit.example.classfit.drive.service;
 
-import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.common.util.DriveUtil;
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -27,11 +26,11 @@ public class DriveRestoreService {
         List<String> restoredPaths = new ArrayList<>();
 
         for (String fileName : fileNames) {
-            String trashPath = generateTrashPath(member, driveType, fileName);
+            String trashPath = DriveUtil.generateTrashPath(member, driveType, fileName);
             List<Tag> filteredTags = getFilteredTags(trashPath);
             String folderPath = extractTags(filteredTags);
 
-            String restoredPath = generateSourcePath(member, driveType, folderPath, fileName);
+            String restoredPath = DriveUtil.generatedOriginPath(member, driveType, folderPath, fileName);
             CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, trashPath, bucketName, restoredPath);
             amazonS3.copyObject(copyRequest);
 
@@ -40,27 +39,6 @@ public class DriveRestoreService {
         }
 
         return restoredPaths;
-    }
-
-    private String generateTrashPath(Member member, DriveType driveType, String fileName) {
-        if (driveType == DriveType.PERSONAL) {
-            return String.format("trash/personal/%d/%s", member.getId(), fileName);
-        } else if (driveType == DriveType.SHARED) {
-            Long academyId = member.getAcademy().getId();
-            return String.format("trash/shared/%d/%s", academyId, fileName);
-        }
-        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
-    }
-
-    private String generateSourcePath(Member member, DriveType driveType, String folderPath, String fileName) {
-        String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
-        if (driveType == DriveType.PERSONAL) {
-            return String.format("personal/%d/%s%s", member.getId(), fullFolderPath, fileName);
-        } else if (driveType == DriveType.SHARED) {
-            Long academyId = member.getAcademy().getId();
-            return String.format("shared/%d/%s%s", academyId, fullFolderPath, fileName);
-        }
-        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
     }
 
     private List<Tag> getFilteredTags(String trashPath) {

--- a/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveRestoreService.java
@@ -28,7 +28,7 @@ public class DriveRestoreService {
         for (String fileName : fileNames) {
             String trashPath = DriveUtil.generateTrashPath(member, driveType, fileName);
             List<Tag> filteredTags = getFilteredTags(trashPath);
-            String folderPath = extractTags(filteredTags);
+            String folderPath = DriveUtil.extractTags(filteredTags, "folderPath");
 
             String restoredPath = DriveUtil.generatedOriginPath(member, driveType, folderPath, fileName);
             CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, trashPath, bucketName, restoredPath);
@@ -51,13 +51,5 @@ public class DriveRestoreService {
 
         amazonS3.setObjectTagging(new SetObjectTaggingRequest(bucketName, trashPath, new ObjectTagging(filteredTags)));
         return filteredTags;
-    }
-
-    private String extractTags(List<Tag> tags) {
-        return tags.stream()
-            .filter(tag -> tag.getKey().equals("folderPath"))
-            .map(Tag::getValue)
-            .findFirst()
-            .orElse("");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
@@ -1,24 +1,20 @@
 package classfit.example.classfit.drive.service;
 
-import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.common.util.DriveUtil;
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
-
-import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
-import static classfit.example.classfit.drive.domain.DriveType.SHARED;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -33,62 +29,35 @@ public class DriveTrashService {
         List<String> trashPaths = new ArrayList<>();
 
         for (String fileName : fileNames) {
-            String sourcePath = generateSourcePath(member, driveType, folderPath, fileName);
-            String trashPath = generateTrashPath(member, driveType, fileName);
+            String originPath = DriveUtil.generatedOriginPath(member, driveType, folderPath, fileName);
+            String trashPath = DriveUtil.generateTrashPath(member, driveType, fileName);
 
-            CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, sourcePath, bucketName, trashPath);
+            CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, originPath, bucketName, trashPath);
             amazonS3.copyObject(copyRequest);
 
-            addDeleteTagsToS3Object(trashPath, folderPath, member);
-            amazonS3.deleteObject(bucketName, sourcePath);
+            addDeleteTagsToS3Object(trashPath, member);
+            amazonS3.deleteObject(bucketName, originPath);
 
             trashPaths.add(trashPath);
         }
         return trashPaths;
     }
 
-    private String generateSourcePath(Member member, DriveType driveType, String folderPath, String fileName) {
-        String fullFolderPath = generateFolderPath(folderPath);
-
-        if (driveType == PERSONAL) {
-            return String.format("personal/%d/%s%s", member.getId(), fullFolderPath, fileName);
-        } else if (driveType == SHARED) {
-            Long academyId = member.getAcademy().getId();
-            return String.format("shared/%d/%s%s", academyId, fullFolderPath, fileName);
-        }
-        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
-    }
-
-    private String generateTrashPath(Member member, DriveType driveType, String fileName) {
-        if (driveType == DriveType.PERSONAL) {
-            return String.format("trash/personal/%d/%s", member.getId(), fileName);
-        } else if (driveType == DriveType.SHARED) {
-            Long academyId = member.getAcademy().getId();
-            return String.format("trash/shared/%d/%s", academyId, fileName);
-        }
-        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
-    }
-
-    private String generateFolderPath(String folderPath) {
-        return folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
-    }
-
-    private void addDeleteTagsToS3Object(String objectKey, String folderPath, Member member) {
+    private void addDeleteTagsToS3Object(String objectKey, Member member) {
         GetObjectTaggingRequest getTaggingRequest = new GetObjectTaggingRequest(bucketName, objectKey);
         GetObjectTaggingResult taggingResult = amazonS3.getObjectTagging(getTaggingRequest);
 
-        Map<String, String> tagMap = taggingResult.getTagSet().stream()
-            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
-
+        List<Tag> existingTags = taggingResult.getTagSet();
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
-        tagMap.put("folderPath", folderPath);
-        tagMap.put("deletedBy", member.getName());
-        tagMap.put("deleteAt", formattedDate);
 
-        List<Tag> updatedTags = tagMap.entrySet().stream()
-            .map(entry -> new Tag(entry.getKey(), entry.getValue()))
-            .collect(Collectors.toList());
+        List<Tag> updatedTags = Stream.concat(
+            existingTags.stream(),
+            Stream.of(
+                new Tag("deletedBy", member.getName()),
+                new Tag("deleteAt", formattedDate)
+            )
+        ).collect(Collectors.toList());
 
         amazonS3.setObjectTagging(new SetObjectTaggingRequest(bucketName, objectKey, new ObjectTagging(updatedTags)));
     }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
@@ -4,10 +4,7 @@ import classfit.example.classfit.common.exception.ClassfitException;
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CopyObjectRequest;
-import com.amazonaws.services.s3.model.ObjectTagging;
-import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
-import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.services.s3.model.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -17,6 +14,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
 import static classfit.example.classfit.drive.domain.DriveType.SHARED;
@@ -75,14 +74,22 @@ public class DriveTrashService {
     }
 
     private void addDeleteTagsToS3Object(String objectKey, String folderPath, Member member) {
+        GetObjectTaggingRequest getTaggingRequest = new GetObjectTaggingRequest(bucketName, objectKey);
+        GetObjectTaggingResult taggingResult = amazonS3.getObjectTagging(getTaggingRequest);
+
+        Map<String, String> tagMap = taggingResult.getTagSet().stream()
+            .collect(Collectors.toMap(Tag::getKey, Tag::getValue));
+
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
+        tagMap.put("folderPath", folderPath);
+        tagMap.put("deletedBy", member.getName());
+        tagMap.put("deleteAt", formattedDate);
 
-        List<Tag> tags = List.of(
-            new Tag("folderPath", generateFolderPath(folderPath)),
-            new Tag("deletedBy", member.getName()),
-            new Tag("deleteAt", formattedDate)
-        );
-        amazonS3.setObjectTagging(new SetObjectTaggingRequest(bucketName, objectKey, new ObjectTagging(tags)));
+        List<Tag> updatedTags = tagMap.entrySet().stream()
+            .map(entry -> new Tag(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toList());
+
+        amazonS3.setObjectTagging(new SetObjectTaggingRequest(bucketName, objectKey, new ObjectTagging(updatedTags)));
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveTrashService.java
@@ -1,0 +1,105 @@
+package classfit.example.classfit.drive.service;
+
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.drive.domain.DriveType;
+import classfit.example.classfit.member.domain.Member;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DriveTrashService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String moveToTrash(Member member, DriveType driveType, String path) {
+        return isFolderPath(path)
+            ? moveFolderToTrash(member, driveType, path)
+            : moveFileToTrash(member, driveType, path);
+    }
+
+    private boolean isFolderPath(String path) {
+        return path.endsWith("/");
+    }
+
+    private String moveFileToTrash(Member member, DriveType driveType, String fileName) {
+        String filePath = generateFullPath(member, driveType, fileName);
+        return moveS3ToTrash(filePath, generateTrashPath(driveType, filePath), member);
+    }
+
+    private String moveFolderToTrash(Member member, DriveType driveType, String folderPath) {
+        List<S3ObjectSummary> objectSummaries = listS3ByPrefix(generateFullPath(member, driveType, folderPath));
+
+        if (objectSummaries.isEmpty()) {
+            return moveS3ToTrash(folderPath, generateTrashPath(driveType, folderPath), member);
+        }
+
+        objectSummaries.forEach(summary -> {
+            String filePath = summary.getKey();
+            moveS3ToTrash(filePath, generateTrashPath(driveType, filePath), member);
+        });
+
+        return folderPath;
+    }
+
+    private String moveS3ToTrash(String sourcePath, String trashPath, Member member) {
+        CopyObjectRequest copyRequest = new CopyObjectRequest(bucketName, sourcePath, bucketName, trashPath);
+        amazonS3.copyObject(copyRequest);
+
+        addDeleteTagsToS3Object(trashPath, member);
+
+        amazonS3.deleteObject(bucketName, sourcePath);
+        return trashPath;
+    }
+
+    private List<S3ObjectSummary> listS3ByPrefix(String prefix) {
+        ListObjectsV2Request request = new ListObjectsV2Request()
+            .withBucketName(bucketName)
+            .withPrefix(prefix);
+
+        ListObjectsV2Result result = amazonS3.listObjectsV2(request);
+        return result.getObjectSummaries();
+    }
+
+    private String generateFullPath(Member member, DriveType driveType, String fileName) {
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("personal/%d/%s", member.getId(), fileName);
+        } else if (driveType == DriveType.SHARED) {
+            Long academyId = member.getAcademy().getId();
+            return String.format("shared/%d/%s", academyId, fileName);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+
+    private String generateTrashPath(DriveType driveType, String filePath) {
+        if (driveType == DriveType.PERSONAL) {
+            return String.format("trash/%s", filePath);
+        } else if (driveType == DriveType.SHARED) {
+            return String.format("trash/%s", filePath);
+        }
+        throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
+    }
+
+    private void addDeleteTagsToS3Object(String objectKey, Member member) {
+        LocalDateTime now = LocalDateTime.now();
+        String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
+
+        List<Tag> tags = List.of(
+            new Tag("deletedBy", member.getName()),
+            new Tag("deleteAt", formattedDate)
+        );
+
+        amazonS3.setObjectTagging(new SetObjectTaggingRequest(bucketName, objectKey, new ObjectTagging(tags)));
+    }
+}

--- a/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
@@ -1,17 +1,15 @@
 package classfit.example.classfit.drive.service;
 
-import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
-import static classfit.example.classfit.drive.domain.DriveType.SHARED;
-
 import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.drive.domain.DriveType;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.ObjectTagging;
-import com.amazonaws.services.s3.model.PutObjectRequest;
-import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
-import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.services.s3.model.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.LocalDateTime;
@@ -19,10 +17,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
+
+import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
+import static classfit.example.classfit.drive.domain.DriveType.SHARED;
 
 @Service
 @RequiredArgsConstructor
@@ -34,13 +31,13 @@ public class DriveUploadService {
 
     public List<String> uploadFiles(@AuthMember Member member, DriveType driveType, List<MultipartFile> files, String folderPath) {
         return files.stream().map(file -> {
-            try {
-                return uploadFileToS3(member, file, driveType, folderPath);
-            } catch (IOException e) {
-                throw new RuntimeException("파일 업로드 중 오류 발생: " + file.getOriginalFilename(), e);
-            }
-        })
-        .collect(Collectors.toList());
+                try {
+                    return uploadFileToS3(member, file, driveType, folderPath);
+                } catch (IOException e) {
+                    throw new RuntimeException("파일 업로드 중 오류 발생: " + file.getOriginalFilename(), e);
+                }
+            })
+            .collect(Collectors.toList());
     }
 
     private String uploadFileToS3(Member member, MultipartFile file, DriveType driveType, String folderPath) throws IOException {
@@ -54,7 +51,7 @@ public class DriveUploadService {
     }
 
     private String generateObjectKey(Member member, MultipartFile file, DriveType driveType, String folderPath) {
-        String uniqueFileName = UUID.randomUUID().toString() + "_" + file.getOriginalFilename();
+        String uniqueFileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
         String fullFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
 
         if (driveType == PERSONAL) {

--- a/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
@@ -46,7 +46,7 @@ public class DriveUploadService {
         try (InputStream inputStream = file.getInputStream()) {
             uploadToS3(objectKey, inputStream, file);
         }
-        addTagsToS3Object(objectKey, member, folderPath);
+        addTagsToS3Object(objectKey, member, folderPath, driveType);
         return amazonS3.getUrl(bucketName, objectKey).toString();
     }
 
@@ -76,13 +76,14 @@ public class DriveUploadService {
         return metadata;
     }
 
-    private void addTagsToS3Object(String objectKey, Member member, String folderPath) {
+    private void addTagsToS3Object(String objectKey, Member member, String folderPath, DriveType driveType) {
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
-        String finalFodlerPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
+        String finalFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
 
         List<Tag> tags = List.of(
-            new Tag("folderPath", finalFodlerPath),
+            new Tag("folderPath", finalFolderPath),
+            new Tag("driveType", driveType.toString().toLowerCase()),
             new Tag("uploadedBy", member.getName()),
             new Tag("uploadedAt", formattedDate)
         );

--- a/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
@@ -79,7 +79,7 @@ public class DriveUploadService {
     private void addTagsToS3Object(String objectKey, Member member, String folderPath, DriveType driveType) {
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
-        String finalFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath + "/" : "";
+        String finalFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath : "";
 
         List<Tag> tags = List.of(
             new Tag("folderPath", finalFolderPath),


### PR DESCRIPTION
## 📌 작업 개요

* 드라이브 휴지통 기능 구현 및 완전 삭제 API를 구현
* AWS Lambda를 사용하여 30일이 지난 S3 객체 삭제 
  * EventBridge로 1일마다 Lamdba 실행

---

## ✅ 작업 내용

### 1. 휴지통 이동 API 구현

![image](https://github.com/user-attachments/assets/9c08c2d7-5601-4505-85dd-7b3e37d4f877)

### 2. 완전 삭제 API 구현

![image](https://github.com/user-attachments/assets/c61473e2-cb2f-438b-b8bd-2db222e4612f)

### 3. 파일 복원 API 구현

![image](https://github.com/user-attachments/assets/a0f1a905-8af0-482f-8a73-8166e51b4765)


### 4. 개인/공용 휴지통 조회 API 구현

![image](https://github.com/user-attachments/assets/79fbaf39-0d85-474d-abac-05645dfcf572)


### 5. (Lambda + EventBrige) 유효 기간이 지난 휴지통 파일 삭제 

![image](https://github.com/user-attachments/assets/35c61b05-bbcd-45c6-bbec-7c4a46b98754)

- EventBrige를 통해 Lambda 함수를 하루마다 실행하여 유효 기간 (30일)이 지난 파일 삭제

### 6. DriveUtil 유틸리티 클래스 생성

---

## 🔗 관련 이슈
- #156

---

## 📂 변경된 파일
- DriveTrashService
- DriveUtil
- FileResponse

---

## 📝 추가 작업 필요 여부
