### PR TITLE
[Fix] 학생 정보 조회 오류 수정

### DIFF
--- a/src/main/java/classfit/example/classfit/member/domain/Member.java
+++ b/src/main/java/classfit/example/classfit/member/domain/Member.java
@@ -1,14 +1,12 @@
 package classfit.example.classfit.member.domain;
 
 import classfit.example.classfit.academy.domain.Academy;
-import classfit.example.classfit.category.domain.MainClass;
 import classfit.example.classfit.common.domain.BaseEntity;
 import classfit.example.classfit.member.dto.request.MemberUpdateInfoRequest;
 import jakarta.persistence.*;
-import java.time.LocalDate;
 import lombok.*;
 
-import java.util.List;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -41,10 +39,10 @@ public class Member extends BaseEntity {
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     private MemberStatus status;
 
-    @Column(nullable = false)
+    @Column(length = 20)
     private LocalDate birthDate;
 
-    @Column(nullable = false)
+    @Column(length = 20)
     private String subject;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/classfit/example/classfit/student/controller/StudentController.java
+++ b/src/main/java/classfit/example/classfit/student/controller/StudentController.java
@@ -1,6 +1,8 @@
 package classfit.example.classfit.student.controller;
 
+import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
+import classfit.example.classfit.member.domain.Member;
 import classfit.example.classfit.student.dto.request.StudentRequest;
 import classfit.example.classfit.student.dto.request.StudentUpdateRequest;
 import classfit.example.classfit.student.dto.response.StudentInfoResponse;
@@ -18,7 +20,7 @@ import java.util.List;
 @RequestMapping("/api/v1/student")
 @RequiredArgsConstructor
 @Tag(name = "학생 컨트롤러", description = "학생 관련 API")
-public class StudentControllerImpl {
+public class StudentController {
 
     private final StudentService studentService;
 
@@ -32,9 +34,9 @@ public class StudentControllerImpl {
 
     @GetMapping("/")
     @Operation(summary = "학생 정보 조회", description = "전체 학생 정보 조회하는 API 입니다. ")
-    public ApiResponse<List<StudentResponse>> studentInfoAll() {
+    public ApiResponse<List<StudentResponse>> studentInfoAll(@AuthMember Member member) {
 
-        List<StudentResponse> studentList = studentService.studentInfoAll();
+        List<StudentResponse> studentList = studentService.studentInfoAll(member);
         return ApiResponse.success(studentList, 200, "FIND STUDENTS");
     }
 

--- a/src/main/java/classfit/example/classfit/student/domain/Student.java
+++ b/src/main/java/classfit/example/classfit/student/domain/Student.java
@@ -39,7 +39,7 @@ public class Student extends BaseEntity {
     @Column(nullable = false, length = 14)
     private String parentNumber;
 
-    @Column(nullable = false, length = 10)
+    @Column(nullable = false, length = 20)
     private String grade;
 
     @Column(nullable = false, length = 100)

--- a/src/main/java/classfit/example/classfit/student/repository/StudentRepository.java
+++ b/src/main/java/classfit/example/classfit/student/repository/StudentRepository.java
@@ -22,4 +22,12 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
     List<String> findSubClassesByStudentId(@Param("studentId") Long studentId);
 
     Optional<List<Student>> findAllByName(String studentName);
+
+    @Query("SELECT s FROM Student s " +
+        "JOIN FETCH ClassStudent cs ON s.id = cs.student.id " +
+        "JOIN FETCH SubClass sc ON cs.subClass.id = sc.id " +
+        "JOIN FETCH MainClass mc ON sc.mainClass.id = mc.id " +
+        "JOIN FETCH Academy a ON mc.academy.id = a.id " +
+        "WHERE a.id = :academyId")
+    List<Student> findStudentsByAcademyId(Long academyId);
 }


### PR DESCRIPTION
## 📌 작업 개요

* 특정 학원에 등록된 학생이 아닌 전체 학생들이 조회되는 오류를 수정

---

## ✅ 작업 내용

1. 학생 조회 로직 수정
    -  조인 조건 수정: 테이블 간 관계를 외래 키를 기준으로 올바르게 조인하도록 JPQL 수정

2. 코드 리팩토링
     -  JPQL의 Fetch Join을 사용
     -  private 메서드 하위로 이동

3. 필드 속성 변경
     - 사용자 생년월일, 담당 과목 필드 속성값 변경

---

## 🔗 관련 이슈
- Closes #188 

---

## 📂 변경된 파일
- StudentRepository
- StudentService
- StudentController
