### PR TITLE
[Fix] 폴더 경로에 맞는 파일 조회

### DIFF
--- a/src/main/java/classfit/example/classfit/drive/service/DriveGetService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveGetService.java
@@ -33,7 +33,10 @@ public class DriveGetService {
         String folderPathWithSlash = folderPath.isEmpty() ? folderPath : folderPath + "/";
         for (S3ObjectSummary summary : objectSummaries) {
             FileResponse fileInfo = buildFileInfo(summary);
-            if (!fileInfo.fileName().equals(folderPathWithSlash)) {
+
+            boolean isNotFolderItself = !fileInfo.fileName().equals(folderPathWithSlash);
+            boolean isInTargetFolder = fileInfo.folderPath().equals(folderPathWithSlash);
+            if (isNotFolderItself && isInTargetFolder) {
                 files.add(fileInfo);
             }
         }
@@ -48,9 +51,10 @@ public class DriveGetService {
         return result.getObjectSummaries().stream()
             .map(this::buildFileInfo)
             .filter(fileInfo -> {
-                boolean isFolder = fileInfo.fileName().equals(folderPathWithSlash);
+                boolean isNotFolderItself = !fileInfo.fileName().equals(folderPathWithSlash);
                 boolean matchesFileName = fileName.isEmpty() || normalize(fileInfo.fileName()).contains(normalize(fileName));
-                return !isFolder && matchesFileName;
+                boolean isInTargetFolder = fileInfo.folderPath().equals(folderPathWithSlash);
+                return isNotFolderItself && matchesFileName && isInTargetFolder;
             })
             .collect(Collectors.toList());
     }
@@ -99,11 +103,11 @@ public class DriveGetService {
         return result.getObjectSummaries().stream()
             .map(this::buildFileInfo)
             .filter(fileInfo -> {
-                boolean isFolder = fileInfo.fileName().equals(folderPathWithSlash);
+                boolean isNotFolderItself = !fileInfo.fileName().equals(folderPathWithSlash);
                 boolean matchesFileType = DriveUtil.getFileType(fileInfo.fileName()).equals(filterFileType);
-                return !isFolder && matchesFileType;
+                boolean isInTargetFolder = fileInfo.folderPath().equals(folderPathWithSlash);
+                return isNotFolderItself && matchesFileType && isInTargetFolder;
             })
             .collect(Collectors.toList());
     }
-
 }


### PR DESCRIPTION
## 📌 작업 개요
* 폴더 경로에 맞는 파일 조회

---

## ✅ 작업 내용

1. 파일 경로와 일치하는지 검증하는 로직 추가

---

## 🔗 관련 이슈
- Closes #181 

---

## 📂 변경된 파일
- DriveGetService.java

---

## 📝 추가 작업 필요 여부
