### PR TITLE
[Fix] 드라이브 휴지통 관련 API 로직 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // swagger
     implementation 'net.nurigo:sdk:4.3.0'
 
+
     //jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
@@ -48,6 +49,8 @@ dependencies {
 
     //s3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'software.amazon.awssdk:s3:2.20.56'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/classfit/example/classfit/common/config/S3Config.java
+++ b/src/main/java/classfit/example/classfit/common/config/S3Config.java
@@ -7,23 +7,42 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 public class S3Config {
+
     @Value("${cloud.aws.credentials.access-key}")
     private String accessKey;
+
     @Value("${cloud.aws.credentials.secret-key}")
     private String secretKey;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 
     @Bean
-    public AmazonS3Client amazonS3Client(){
+    public AmazonS3Client amazonS3Client() {
         return (AmazonS3Client) AmazonS3ClientBuilder.standard()
             .withCredentials(
-                new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey,secretKey))
+                new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey))
             )
             .withRegion(region)
+            .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+                )
+            )
+            .region(Region.of(region))
             .build();
     }
 }

--- a/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
+++ b/src/main/java/classfit/example/classfit/common/util/DriveUtil.java
@@ -6,13 +6,10 @@ import classfit.example.classfit.drive.domain.FileType;
 import classfit.example.classfit.drive.dto.response.FileResponse;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
-import com.amazonaws.services.s3.model.Tag;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Map;
 
 import static classfit.example.classfit.drive.domain.DriveType.PERSONAL;
@@ -32,22 +29,6 @@ public class DriveUtil {
         throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
     }
 
-    public static String generateTrashPath(Member member, DriveType driveType, String fileName) {
-
-        String basePath;
-
-        if (driveType == DriveType.PERSONAL) {
-            basePath = String.format("trash/personal/%d/", member.getId());
-        } else if (driveType == DriveType.SHARED) {
-            Long academyId = member.getAcademy().getId();
-            basePath = String.format("trash/shared/%d/", academyId);
-        } else {
-            throw new ClassfitException("지원하지 않는 드라이브 타입입니다.", HttpStatus.NO_CONTENT);
-        }
-
-        return (fileName != null && !fileName.trim().isEmpty()) ? basePath + fileName : basePath;
-    }
-
     public static String buildPrefix(DriveType driveType, Member member, String folderPath) {
         String basePrefix;
 
@@ -65,15 +46,6 @@ public class DriveUtil {
         return basePrefix + folderPath + "/";
     }
 
-    public static String extractTags(List<Tag> tags, String tagKey) {
-        return tags.stream()
-            .filter(tag -> tag.getKey().equals(tagKey))
-            .map(Tag::getValue)
-            .findFirst()
-            .orElse("");
-    }
-
-    @NotNull
     public static FileResponse getFileResponse(S3ObjectSummary summary, String fileName,
                                                String fileUrl,
                                                Map<String, String> tagMap) {
@@ -120,12 +92,10 @@ public class DriveUtil {
     private static String formatFileSize(long sizeInBytes) {
         double sizeInKB = sizeInBytes / 1024.0;
         if (sizeInKB >= 1024) {
-            // 1MB 이상이면 MB 단위로 표시
             double sizeInMB = sizeInKB / 1024.0;
-            return String.format("%.1f MB", sizeInMB); // 소수점 한 자리까지 MB로 표시
+            return String.format("%.1f MB", sizeInMB);
         }
-        // 1MB 미만이면 KB 단위로 표시
-        return String.format("%.1f KB", sizeInKB); // 소수점 한 자리까지 KB로 표시
+        return String.format("%.1f KB", sizeInKB);
     }
 
     private static String getFileNameWithoutPrefix(String objectKey) {

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveFolderController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveFolderController.java
@@ -8,7 +8,6 @@ import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -48,18 +47,5 @@ public class DriveFolderController {
     ) {
         List<String> folders = driveFolderService.getFolders(member, driveType, folderPath);
         return ApiResponse.success(folders, 200, "폴더 목록 조회 성공");
-    }
-
-    @DeleteMapping("/folder")
-    @Operation(summary = "폴더 삭제", description = "폴더를 삭제하는 API입니다.")
-    public ApiResponse<Nullable> deleteFolder(
-        @AuthMember Member member,
-        @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
-        @RequestParam DriveType driveType,
-        @Parameter(description = "삭제할 폴더 이름입니다.")
-        @RequestParam String folderName
-    ) {
-        driveFolderService.deleteFolder(member, driveType, folderName);
-        return ApiResponse.success(null, 200, "SUCCESS");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
+++ b/src/main/java/classfit/example/classfit/drive/controller/DriveTrashController.java
@@ -32,15 +32,17 @@ public class DriveTrashController {
     public ApiResponse<List<FileResponse>> trashList(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
-        @RequestParam DriveType driveType
+        @RequestParam DriveType driveType,
+        @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더로 지정됩니다.")
+        @RequestParam(required = false, defaultValue = "") String folderPath
     ) {
-        List<FileResponse> filesFromTrash = driveTrashService.getFilesFromTrash(member, driveType);
+        List<FileResponse> filesFromTrash = driveTrashService.getFilesFromTrash(member, driveType, folderPath);
         return ApiResponse.success(filesFromTrash, 200, "조회 성공");
     }
 
     @PostMapping("/trash")
     @Operation(summary = "휴지통 이동", description = "휴지통 이동 API 입니다.")
-    public ApiResponse<List<String>> moveToTrash(
+    public ApiResponse<List<String>> storeTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
@@ -49,20 +51,20 @@ public class DriveTrashController {
         @Parameter(description = "파일 이름")
         @RequestParam List<String> fileNames
     ) {
-        List<String> trashPathList = driveTrashService.moveToTrash(member, driveType, folderPath, fileNames);
+        List<String> trashPathList = driveTrashService.storeTrash(member, driveType, folderPath, fileNames);
         return ApiResponse.success(trashPathList, 200, "휴지통 이동 완료");
     }
 
     @PostMapping("/trash/restore")
     @Operation(summary = "휴지통 복원", description = "휴지통 복원 API 입니다.")
-    public ApiResponse<List<String>> restoreFromTrash(
+    public ApiResponse<List<String>> restoreTrash(
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
         @Parameter(description = "파일 이름")
         @RequestParam List<String> fileNames
     ) {
-        List<String> restorePathList = driveRestoreService.restoreFromTrash(member, driveType, fileNames);
+        List<String> restorePathList = driveRestoreService.restoreTrash(member, driveType, fileNames);
         return ApiResponse.success(restorePathList, 200, "복원 성공");
     }
 
@@ -72,10 +74,13 @@ public class DriveTrashController {
         @AuthMember Member member,
         @Parameter(description = "내 드라이브는 PERSONAL, 공용 드라이브는 SHARED 입니다.")
         @RequestParam DriveType driveType,
+        @Parameter(description = "폴더 경로입니다. 비어 있으면 루트 폴더로 지정됩니다.")
+        @RequestParam(required = false, defaultValue = "") String folderPath,
         @Parameter(description = "파일 이름")
-        @RequestParam List<String> fileName
+        @RequestParam List<String> fileNames
+
     ) {
-        driveDeleteService.deleteFromTrash(member, driveType, fileName);
+        driveDeleteService.deleteFromTrash(member, driveType, folderPath, fileNames);
         return ApiResponse.success(null, 200, "삭제 성공");
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveFolderService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveFolderService.java
@@ -2,7 +2,6 @@ package classfit.example.classfit.drive.service;
 
 import classfit.example.classfit.common.util.DriveUtil;
 import classfit.example.classfit.drive.domain.DriveType;
-import classfit.example.classfit.drive.dto.response.FileResponse;
 import classfit.example.classfit.member.domain.Member;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.*;
@@ -100,17 +99,5 @@ public class DriveFolderService {
         return result.getCommonPrefixes().stream()
             .map(folder -> folder.substring(prefix.length()))
             .collect(Collectors.toList());
-    }
-
-    public void deleteFolder(Member member, DriveType driveType, String folderName) {
-        List<FileResponse> filesFromS3 = driveGetService.getFilesFromS3(member, driveType, folderName);
-        List<String> strings = filesFromS3.stream()
-            .map(FileResponse::fileName)
-            .collect(Collectors.toList());
-
-        driveTrashService.moveToTrash(member, driveType, folderName, strings);
-
-        String prefix = DriveUtil.buildPrefix(driveType, member, folderName);
-        amazonS3.deleteObject(new DeleteObjectRequest(bucketName, prefix));
     }
 }

--- a/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
+++ b/src/main/java/classfit/example/classfit/drive/service/DriveUploadService.java
@@ -67,7 +67,6 @@ public class DriveUploadService {
         LocalDateTime now = LocalDateTime.now();
         String formattedDate = now.format(DateTimeFormatter.ISO_DATE_TIME);
         String finalFolderPath = folderPath != null && !folderPath.trim().isEmpty() ? folderPath : "";
-        finalFolderPath = finalFolderPath + "/";
 
         List<Tag> tags = List.of(
             new Tag("folderPath", finalFolderPath),


### PR DESCRIPTION
S3 버전 관리 기능을 활용한 드라이브 휴지통 API 구현

## 📌 작업 개요

* S3 버전 관리 기능을 활용하여 드라이브 휴지통 관련 API를 개선
* 기존 로직의 오류 수정

---

## ✅ 작업 내용


###  1.  휴지통 이동 API 오류 수정

**해당 객체의 모든 버전을 영구 삭제**

![image](https://github.com/user-attachments/assets/c63ea4be-9936-467d-a62e-9f3897c4180e)


###  2. 휴지통 복원 API 오류 수정
  
**삭제 마커가 달린 객체를 복원할 수 있도록 S3의 이전 버전 복원 기능**
    
![image](https://github.com/user-attachments/assets/58d381aa-0161-434b-8d79-223fa3bc8bf7)


###  3. 휴지통 조회 API 오류 수정

**삭제 마커가 달린 객체를 복원할 수 있도록 S3의 이전 버전 복원 기능**

![image](https://github.com/user-attachments/assets/c0f1d29b-766e-40cf-a840-ee58991e5d6c)

###  4.  휴지통 비우기 API 오류 수정

**해당 객체의 모든 버전을 영구 삭제**

![image](https://github.com/user-attachments/assets/adfa6c15-e34e-4e6c-be4c-7db27a82c2ab)

---

## 🔗 관련 이슈
- Closes #211 

---

## 📂 변경된 파일
- DriveTrashController
- DriveTrashService
- DriveTrashService


---

## 📝 추가 작업 필요 여부
- [ ] 코드 리팩토링 및 로직 개선
