### PR TITLE
[Fix] 직원 초대 API 에러 수정

### DIFF
--- a/src/main/java/classfit/example/classfit/academy/controller/AcademyController.java
+++ b/src/main/java/classfit/example/classfit/academy/controller/AcademyController.java
@@ -4,9 +4,7 @@ import classfit.example.classfit.academy.dto.request.AcademyCreateRequest;
 import classfit.example.classfit.academy.dto.request.AcademyJoinRequest;
 import classfit.example.classfit.academy.dto.response.AcademyResponse;
 import classfit.example.classfit.academy.service.AcademyService;
-import classfit.example.classfit.auth.annotation.AuthMember;
 import classfit.example.classfit.common.ApiResponse;
-import classfit.example.classfit.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Nullable;
@@ -37,8 +35,8 @@ public class AcademyController {
 
     @PostMapping("/invite")
     @Operation(summary = "학원 가입", description = "학원 코드로 등록된 학원에 가입하는 API 입니다.")
-    public ApiResponse<Nullable> joinAcademy(@AuthMember Member member, @RequestBody AcademyJoinRequest request) {
-        academyService.joinAcademy(member, request);
+    public ApiResponse<Nullable> joinAcademy(@RequestBody AcademyJoinRequest request) {
+        academyService.joinAcademy(request);
         return ApiResponse.success(null, 200, "학원 가입을 성공했습니다.");
     }
 }

--- a/src/main/java/classfit/example/classfit/academy/repository/AcademyRepository.java
+++ b/src/main/java/classfit/example/classfit/academy/repository/AcademyRepository.java
@@ -10,4 +10,6 @@ public interface AcademyRepository extends JpaRepository<Academy, Long> {
     boolean existsByName(String name);
 
     Optional<Academy> findByCode(String code);
+
+    boolean existsByCode(String code);
 }

--- a/src/main/java/classfit/example/classfit/academy/service/AcademyService.java
+++ b/src/main/java/classfit/example/classfit/academy/service/AcademyService.java
@@ -28,6 +28,10 @@ public class AcademyService {
     @Transactional
     public AcademyResponse createAcademy(AcademyCreateRequest request) {
 
+        if (academyRepository.existsByCode(request.code())) {
+            throw new ClassfitException("이미 등록된 코드가 존재합니다. 다시 시도해 주세요.", HttpStatus.NOT_IMPLEMENTED);
+        }
+
         if (academyRepository.existsByName(request.name())) {
             throw new ClassfitException("이미 등록된 학원명이 존재합니다. 다시 시도해 주세요.", HttpStatus.NOT_IMPLEMENTED);
         }
@@ -45,13 +49,16 @@ public class AcademyService {
     }
 
     @Transactional
-    public void joinAcademy(Member member, AcademyJoinRequest request) {
+    public void joinAcademy(AcademyJoinRequest request) {
 
         Academy academy = academyRepository.findByCode(request.code())
             .orElseThrow(() -> new ClassfitException("유효하지 않은 코드입니다.", HttpStatus.NOT_FOUND));
 
         Invitation invitation = invitationRepository.findByAcademyIdAndEmail(academy.getId(), request.email())
             .orElseThrow(() -> new ClassfitException("학원으로부터 초대받지 않은 계정입니다.", HttpStatus.NOT_FOUND));
+
+        Member member = memberRepository.findByEmail(request.email())
+            .orElseThrow(() -> new ClassfitException("존재하지 않는 계정입니다.", HttpStatus.NOT_FOUND));
 
         invitation.updateStatus(InvitationStatus.COMPLETED);
         member.updateRole("MEMBER");

--- a/src/main/java/classfit/example/classfit/common/config/SecurityConfig.java
+++ b/src/main/java/classfit/example/classfit/common/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
         security
             .authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()  // 스웨거 관련 엔드포인트 허용
-                .requestMatchers("/api/v1/signin", "/api/v1/signup", "/api/v1/reissue", "/api/v1/mail/send", "/api/v1/mail/verify").permitAll()
+                .requestMatchers("/api/v1/signin", "/api/v1/signup", "/api/v1/password", "/api/v1/reissue", "/api/v1/mail/send", "/api/v1/mail/verify").permitAll()
                 .requestMatchers("/api/v1/academy/code", "/api/v1/academy/register", "/api/v1/academy/create", "/api/v1/academy/invite").permitAll()
                 .requestMatchers("/api/v1/**").hasAnyRole("MEMBER", "ADMIN")
                 .requestMatchers("/admin/**").hasRole("ADMIN")

--- a/src/main/java/classfit/example/classfit/invitation/repository/InvitationRepository.java
+++ b/src/main/java/classfit/example/classfit/invitation/repository/InvitationRepository.java
@@ -14,4 +14,6 @@ public interface InvitationRepository extends JpaRepository<Invitation, Long> {
     List<Invitation> findByAcademy(Academy academy);
 
     Optional<Invitation> findByAcademyIdAndEmail(Long id, String email);
+
+    boolean existsByAcademyIdAndEmail(Long id, String email);
 }

--- a/src/main/java/classfit/example/classfit/invitation/service/InvitationService.java
+++ b/src/main/java/classfit/example/classfit/invitation/service/InvitationService.java
@@ -7,7 +7,6 @@ import classfit.example.classfit.invitation.dto.request.InvitationRequest;
 import classfit.example.classfit.invitation.dto.response.InvitationResponse;
 import classfit.example.classfit.invitation.repository.InvitationRepository;
 import classfit.example.classfit.mail.dto.request.EmailPurpose;
-import classfit.example.classfit.mail.handler.InvitationHandler;
 import classfit.example.classfit.mail.service.EmailService;
 import classfit.example.classfit.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +23,6 @@ public class InvitationService {
 
     private final InvitationRepository invitationRepository;
     private final EmailService emailService;
-    private final InvitationHandler invitationHandler;
 
     @Transactional
     public String findAcademyCode(Member member) {
@@ -39,10 +37,21 @@ public class InvitationService {
 
     @Transactional
     public void inviteStaffByEmail(Member member, InvitationRequest request) {
-        emailService.sendEmail(request.email(), EmailPurpose.INVITATION);
-        Invitation invitation = request.toEntity(member.getAcademy());
 
-        invitationRepository.save(invitation);
+        boolean exists = invitationRepository.existsByAcademyIdAndEmail(
+            member.getAcademy().getId(),
+            request.email()
+        );
+        System.out.println("Academy ID: " + member.getAcademy().getId());
+        System.out.println("Request Email: " + request.email());
+        System.out.println(exists + " exists");
+
+        if (!exists) {
+            Invitation invitation = request.toEntity(member.getAcademy());
+            invitationRepository.save(invitation);
+        }
+
+        emailService.sendEmail(request.email(), EmailPurpose.INVITATION);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/classfit/example/classfit/invitation/service/InvitationService.java
+++ b/src/main/java/classfit/example/classfit/invitation/service/InvitationService.java
@@ -7,6 +7,7 @@ import classfit.example.classfit.invitation.dto.request.InvitationRequest;
 import classfit.example.classfit.invitation.dto.response.InvitationResponse;
 import classfit.example.classfit.invitation.repository.InvitationRepository;
 import classfit.example.classfit.mail.dto.request.EmailPurpose;
+import classfit.example.classfit.mail.handler.InvitationHandler;
 import classfit.example.classfit.mail.service.EmailService;
 import classfit.example.classfit.member.domain.Member;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class InvitationService {
 
     private final InvitationRepository invitationRepository;
     private final EmailService emailService;
+    private final InvitationHandler invitationHandler;
 
     @Transactional
     public String findAcademyCode(Member member) {

--- a/src/main/java/classfit/example/classfit/mail/handler/InvitationHandler.java
+++ b/src/main/java/classfit/example/classfit/mail/handler/InvitationHandler.java
@@ -1,7 +1,13 @@
 package classfit.example.classfit.mail.handler;
 
+import classfit.example.classfit.academy.domain.Academy;
+import classfit.example.classfit.common.exception.ClassfitException;
+import classfit.example.classfit.common.util.SecurityUtil;
 import classfit.example.classfit.mail.dto.request.EmailPurpose;
+import classfit.example.classfit.member.domain.Member;
+import classfit.example.classfit.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -10,6 +16,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class InvitationHandler implements EmailHandler {
 
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean supports(EmailPurpose purpose) {
@@ -33,6 +40,14 @@ public class InvitationHandler implements EmailHandler {
 
     @Override
     public Map<String, Object> getTemplateVariables(String authCode) {
-        return Map.of("code", authCode, "extraInfo", "초대 관련 메시지");
+        Academy academy = getAcademy();
+        return Map.of("code", academy.getCode());
+    }
+
+    private Academy getAcademy() {
+        Long currentMemberId = SecurityUtil.getCurrentMemberId();
+        Member member = memberRepository.findById(currentMemberId)
+            .orElseThrow(() -> new ClassfitException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+        return member.getAcademy();
     }
 }

--- a/src/main/java/classfit/example/classfit/mail/service/EmailService.java
+++ b/src/main/java/classfit/example/classfit/mail/service/EmailService.java
@@ -52,7 +52,6 @@ public class EmailService {
         }
 
         return EmailResponse.of(email);
-
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 작업 개요

*  관리자가 직원 이메일로 학원 코드 발송 시, 발송된 인증 코드로 가입이 되지 않는 오류 수정.

---

## ✅ 작업 내용

1. 초대 시, 랜덤 코드가 아닌 학원 코드 발송하도록 로직 수정
2. 발송된 코드로 학원 가입이 가능하도록 로직 수정
3. 직원 재초대 시, 중복 데이터가 저장되지 않도록 수정

---

## 🔗 관련 이슈
- Closes #223 

---

## 📂 변경된 파일
- InvitationService
- InvitationRepository
- EmailHandler


---

